### PR TITLE
add post-merge-cleanup workflow

### DIFF
--- a/.github/workflows/post-merge-cleanup.yaml
+++ b/.github/workflows/post-merge-cleanup.yaml
@@ -1,0 +1,16 @@
+name: Delete PR branch and gh-pages preview after PR merge
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  post-merge-cleanup:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: delete PR branch ${{ github.event.pull_request.head.ref }}
+        run: git push origin --delete ${{ github.event.pull_request.head.ref }}
+      - name: delete gh-pages preview branch gh-pages-${{ github.event.pull_request.head.ref }}
+        run: git push origin --delete gh-pages-${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
deletes PR branch and gh-pages preview branch after PR merge