### PR TITLE
Place resources under attachments key and rename resource_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ scratch
 scripts/site.config.json
 scripts/utils.js
 new-rdf.yaml
-collection
 
 # local env files
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ scratch
 scripts/site.config.json
 scripts/utils.js
 new-rdf.yaml
+collection
 
 # local env files
 .env.local

--- a/collection_rdf_template.yaml
+++ b/collection_rdf_template.yaml
@@ -49,8 +49,8 @@ config:
     - id: hpa
       source: >-
         https://raw.githubusercontent.com/CellProfiling/HPA-model-zoo/master/manifest.bioimage.io.yaml
-
-model: []
-application: []
-notebook: []
-dataset: []
+attachments:
+  model: []
+  application: []
+  notebook: []
+  dataset: []

--- a/collection_rdf_template.yaml
+++ b/collection_rdf_template.yaml
@@ -25,7 +25,6 @@ config:
   resource_types:
     - model
     - application
-    - notebook
     - dataset
   default_type: model
   url_root: >-
@@ -52,5 +51,4 @@ config:
 attachments:
   model: []
   application: []
-  notebook: []
   dataset: []

--- a/scripts/generate_collection_rdf.py
+++ b/scripts/generate_collection_rdf.py
@@ -49,7 +49,7 @@ def main() -> int:
             continue
 
         # deploy from preview if it exists
-        preview_branch = f"gh-pages-auto-update-{r['resource_id']}"
+        preview_branch = f"gh-pages-auto-update-{r['id']}"
         from_preview = f"origin/{preview_branch}" in remote_branches
         # checkout preview separately
         ghp_prev = gh_pages_previews / preview_branch
@@ -101,7 +101,7 @@ def main() -> int:
 
             if latest_version is None:
                 latest_version = this_version
-                latest_version["resource_id"] = r["resource_id"]
+                latest_version["id"] = r["id"]
                 latest_version["previous_versions"] = []
             else:
                 latest_version["previous_versions"].append(this_version)

--- a/scripts/generate_collection_rdf.py
+++ b/scripts/generate_collection_rdf.py
@@ -23,6 +23,8 @@ def set_gh_actions_output(name: str, output: str):
 def main() -> int:
     collection_path = Path("collection")
     rdf = yaml.load(Path("collection_rdf_template.yaml"))
+    rdf['attachments'] = rdf.get('attachments', {})
+    attachments = rdf['attachments']
 
     subprocess.run(["git", "fetch"])
     remote_branch_proc = subprocess.run(["git", "branch", "-r"], capture_output=True, text=True)
@@ -34,7 +36,7 @@ def main() -> int:
     subprocess.run(["git", "worktree", "add", str(gh_pages), f"gh-pages"])
     gh_pages_previews = Path("dist/gh-pages-previews")
     gh_pages_update = Path("dist/gh-pages-update")
-    gh_pages_update.mkdir(parents=True)
+    gh_pages_update.mkdir(parents=True, exist_ok=True)
 
     processed_gh_pages_previews = []
 
@@ -108,7 +110,8 @@ def main() -> int:
             print(f"Ignoring resource at {r_path} without any accepted versions")
         else:
             type_ = latest_version.get("type", "unknown")
-            type_list = rdf.get(type_)
+            attachments[type_] = attachments.get(type_)
+            type_list = attachments[type_]
             if isinstance(type_list, list):
                 type_list.append(latest_version)
                 n_accepted[type_] = n_accepted.get(type_, 0) + 1

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -85,8 +85,8 @@ def write_resource(
         resource = {
             "status": "pending",
             "versions": [new_version],
-            "resource_id": resource_id,
-            "resource_doi": resource_doi,
+            "id": resource_id,
+            "doi": resource_doi,
         }
 
     assert isinstance(resource, dict)
@@ -278,7 +278,7 @@ def main(collection_folder: Path) -> int:
 
     updates = [
         {
-            "resource_id": k,
+            "id": k,
             "new_version_ids": json.dumps([vv["version_id"] for vv in v]),
             "new_version_ids_md": "\n".join(["  - " + vv["version_id"] for vv in v]),
             "new_version_sources": json.dumps([vv["source"] for vv in v]),

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -270,7 +270,7 @@ def update_from_github(collection_folder: Path, updated_resources: DefaultDict[s
             print(f"Failed to process collection {p_source} for {p_id} partner: {e}")
 
 
-def main(collection_folder: Path) -> int:
+def main(collection_folder: Path = "collection") -> int:
     updated_resources: DefaultDict[str, List[Dict[str, Union[dict, str]]]] = defaultdict(list)
 
     update_from_zenodo(collection_folder, updated_resources)


### PR DESCRIPTION
To be compatible with the website, we need to move all the resource categories under the `attachements` key and rename `resource_id` into `id`.