### PR TITLE
Simplify building process and limit PR number

### DIFF
--- a/.github/workflows/auto_update_main.yaml
+++ b/.github/workflows/auto_update_main.yaml
@@ -8,6 +8,22 @@ on:
     - cron:  '0 1,13 * * *'
 
 jobs:
+  build-collection:  # deploy collection rdf to gh-pages
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install script deps
+      run: pip install typer ruamel.yaml bioimageio.spec boltons
+    - name: generate collection rdf
+      run: python scripts/generate_collection_rdf.py
+    - name: Deploy collection rdf to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        clean: false
+        branch: gh-pages
+        folder: dist/gh-pages
+
   collect-new-resources:
     runs-on: ubuntu-latest
     outputs:
@@ -23,42 +39,13 @@ jobs:
       run: pip install bioimageio.spec PyGithub lxml
     - name: update known resources
       id: update_known
-      run: python scripts/update_known_resources.py collection
-    - name: Commit files and rebase
-      if: steps.update_known.outputs.found_new_resources == 'yes'
-      run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add collection
-        git commit -m "Add new resources" -a
-        git pull --rebase
-    - name: Push changes
-      if: steps.update_known.outputs.found_new_resources == 'yes'
-      uses: ad-m/github-push-action@master
+      run: python scripts/update_known_resources.py collection 5
+    - name: "Upload updated collection"
+      uses: actions/upload-artifact@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
-
-
-  deploy:  # deploy new resource versions and collection rdf to gh-pages
-    runs-on: ubuntu-latest
-    outputs:
-      processed_gh_pages_previews: ${{ steps.gen_coll_rdf.outputs.processed_gh_pages_previews }}
-      processed_any_gh_pages_previews: ${{ steps.gen_coll_rdf.outputs.processed_any_gh_pages_previews }}
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: install script deps
-      run: pip install typer ruamel.yaml bioimageio.spec boltons
-    - name: generate collection rdf
-      id: gen_coll_rdf
-      run: python scripts/generate_collection_rdf.py
-    - name: Deploy collection rdf to gh-pages 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.4
-      with:
-        clean: false
-        branch: gh-pages
-        folder: dist/gh-pages-update
+        name: updated-collection
+        path: collection
+        retention-days: 1
 
   open-pr:
     needs: [collect-new-resources]
@@ -71,12 +58,11 @@ jobs:
       matrix: ${{ fromJson(needs.collect-new-resources.outputs.updated_resources_matrix) }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: download new collection
+      uses: actions/download-artifact@v2
       with:
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-    - name: Pull latest auto commit
-      run: git pull origin
+        name: updated-collection
+        path: collection
     - name: install script deps
       run: pip install typer ruamel.yaml
     - name: set resource status to accepted
@@ -110,23 +96,3 @@ jobs:
         labels: |
           auto-update
         draft: false
-
-  rm-previews:
-    needs: deploy
-    if: needs.deploy.outputs.processed_any_gh_pages_previews == 'yes'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix: ${{ fromJson(needs.deploy.outputs.processed_gh_pages_previews) }}  # preview-branch: [...]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: check if branch still exists
-        id: ls-remote
-        run: |
-          out=$(git ls-remote --heads origin ${{ matrix.preview-branch }})
-          echo "::set-output name=out::$out"
-      - name: delete ${{ matrix.preview-branch }}
-        if: steps.ls-remote.outputs.out
-        run: git push origin --delete ${{ matrix.preview-branch }}

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -74,7 +74,7 @@ def write_resource(
             raise ValueError(resource["status"])
 
         for idx, known_version in enumerate(list(resource["versions"])):
-            if known_version["version_id"] == version_id:
+            if known_version["version_id"] == version_id or new_version.get("source") == known_version.get("source"):
                 if overwrite:
                     old_version = resource["versions"].pop(idx)
                     old_version.pop("status", None)  # don't overwrite status
@@ -305,11 +305,14 @@ def update_from_github(collection_folder: Path, updated_resources: DefaultDict[s
             print(f"Failed to process collection {p_source} for {p_id} partner: {e}")
 
 
-def main(collection_folder: Path) -> int:
+def main(collection_folder: Path, max_resource_count: int) -> int:
     updated_resources: DefaultDict[str, List[Dict[str, Union[dict, str]]]] = defaultdict(list)
 
     update_from_zenodo(collection_folder, updated_resources)
     update_from_github(collection_folder, updated_resources)
+
+    # limit the number of PR created
+    updated_resources = updated_resources[:max_resource_count]
 
     updates = [
         {


### PR DESCRIPTION
This PR introduce the following changes:
 * Upload the new resource items as artefacts instead of pushing directly to main branch. IMO, we should avoid pushing to the main branch in CI and make sure human edited content is not changed by the CI. If needed, we can use gh-pages branch for storing CI content. The other different with artefacts vs pushing to a branch is that artefacts are independent from each other, while the branch is shared.
 * Move the deployment step as the first step on the main branch, this is because building the collection does not dependent on the new resource items (as they will be in pending state anyway) and we want to see the changes as soon as possible.
 * Remove the preview branch for the main branch CI. I might missed the point of creating a bunch of preview branches, but I think it's much easier to just generate the collection immediately and push to gh-pages. Do we really need the preview branches for gh-pages? Or pehraps you can just create subfolders in gh-pages? I think we should reduce the number of branches since there are already many branches created by the PRs.
 * Limit the PR number. We have too many PRs (110 for now) opened automatically, I know it won't be a problem later, but having PR number limit will be helpful anyway to prevent accidentally flooding the PRs. The current behavior is that it will only open 5, and if there are more new items, new PRs will come if we start to merge some of them.