### PR TITLE
Fix collection generation and use gh-pages to preview

### DIFF
--- a/.github/workflows/auto_update_main.yaml
+++ b/.github/workflows/auto_update_main.yaml
@@ -87,7 +87,7 @@ jobs:
           sources of new versions:
           ${{ matrix.update.new_version_sources_md }}
 
-          deployment preview (will be) available at: [gh-pages-auto-update-${{ matrix.update.resource_id }}](/bioimage-io/collection-bioimage-io/tree/gh-pages-auto-update-${{ matrix.update.resource_id }})
+          deployment preview (will be) available at: [gh-pages](/bioimage-io/collection-bioimage-io/tree/gh-pages/resources/${{ matrix.update.resource_id }})
           maintainers: ${{ matrix.update.maintainers }}
 
           IMPORTANT: If new resource versions are detected this PR branch is beeing **force-pushed**.

--- a/.github/workflows/auto_update_pr.yaml
+++ b/.github/workflows/auto_update_pr.yaml
@@ -104,14 +104,15 @@ jobs:
         path: artifacts
     - name: prepare deployment
       run: python scripts/prepare_to_deploy_preview.py collection ${{ github.event.pull_request.head.ref }} dist/resources '${{ needs.get-pending.outputs.pending_matrix }}' artifacts
-    - name: Deploy to gh-pages-${{ github.event.pull_request.head.ref }} 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.4
+    - name: Deploy to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.7
       with:
-        branch: gh-pages-${{ github.event.pull_request.head.ref }}  # The branch the action should deploy to.
-        folder: dist  # The folder the action should deploy.
+        branch: gh-pages
+        clean: false # Keeping the old files
+        folder: dist
 
   passed-validation:
-    needs: deploy-preview
+    needs: dynamic-validation
     if: always()
     runs-on: ubuntu-latest
 

--- a/collection/deepimagej/2DUNetZeroCostDL4Mic/resource.yaml
+++ b/collection/deepimagej/2DUNetZeroCostDL4Mic/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/2DUNetZeroCostDL4Mic
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:48.979562
+- created: '2021-12-26T23:54:49.284520'
   download_url: https://sandbox.zenodo.org/record/904905/files/DeepImageJ_2D_UNet_ZeroCostDL4Mic.zip
   links: [zero/Notebook_U-Net_2D_ZeroCostDL4Mic_DeepImageJ, deepimagej, imjoy/BioImageIO-Packager]
   name: 2D UNet - ZeroCostDL4Mic
   source: https://raw.githubusercontent.com/deepimagej/models/master/2du-net_zerocostdl4mic/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:12.708065
-  download_url: https://sandbox.zenodo.org/record/904905/files/DeepImageJ_2D_UNet_ZeroCostDL4Mic.zip
-  links: [zero/Notebook_U-Net_2D_ZeroCostDL4Mic_DeepImageJ, deepimagej, imjoy/BioImageIO-Packager]
-  name: 2D UNet - ZeroCostDL4Mic
-  source: https://raw.githubusercontent.com/deepimagej/models/master/2du-net_zerocostdl4mic/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/3DUNetZeroCostDL4Mic/resource.yaml
+++ b/collection/deepimagej/3DUNetZeroCostDL4Mic/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/3DUNetZeroCostDL4Mic
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:50.803952
+- created: '2021-12-26T23:54:52.484315'
   download_url: https://sandbox.zenodo.org/record/907831/files/3DUNet_ZeroCostDL4Mic.bioimage.io.model.zip
   links: [deepimagej, zero/Notebook_U-Net_3D_ZeroCostDL4Mic_DeepImageJ, imjoy/BioImageIO-Packager]
   name: 3D U-Net - ZeroCostDL4Mic
   source: https://raw.githubusercontent.com/deepimagej/models/master/3du-net_zerocostdl4mic/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:17.416036
-  download_url: https://sandbox.zenodo.org/record/907831/files/3DUNet_ZeroCostDL4Mic.bioimage.io.model.zip
-  links: [deepimagej, zero/Notebook_U-Net_3D_ZeroCostDL4Mic_DeepImageJ, imjoy/BioImageIO-Packager]
-  name: 3D U-Net - ZeroCostDL4Mic
-  source: https://raw.githubusercontent.com/deepimagej/models/master/3du-net_zerocostdl4mic/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/DeepSTORMZeroCostDL4Mic/resource.yaml
+++ b/collection/deepimagej/DeepSTORMZeroCostDL4Mic/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/DeepSTORMZeroCostDL4Mic
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:48.772892
+- created: '2021-12-26T23:54:49.068404'
   download_url: https://sandbox.zenodo.org/record/907832/files/bioimage.io.model.zip
   links: [zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic_DeepImageJ, deepimagej, imjoy/BioImageIO-Packager]
   name: Glial Cell SMLM (DeepSTORM - ZeroCostDL4Mic)
   source: https://raw.githubusercontent.com/deepimagej/models/master/deepstorm_zerocostdl4mic/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:12.188163
-  download_url: https://sandbox.zenodo.org/record/907832/files/bioimage.io.model.zip
-  links: [zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic_DeepImageJ, deepimagej, imjoy/BioImageIO-Packager]
-  name: Glial Cell SMLM (DeepSTORM - ZeroCostDL4Mic)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/deepstorm_zerocostdl4mic/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/EVsTEMsegmentationFRUNet/resource.yaml
+++ b/collection/deepimagej/EVsTEMsegmentationFRUNet/resource.yaml
@@ -2,7 +2,7 @@ id: deepimagej/EVsTEMsegmentationFRUNet
 status: pending
 type: application
 versions:
-- created: 2021-12-26 19:33:51.403043
+- created: '2021-12-26T23:54:53.419635'
   name: Small extracellular vesicle instance segmentation (FRU-Net)
   source:
     authors:
@@ -26,11 +26,11 @@ versions:
       to use it in Google Colaboratory. It will download the original code and dataset,
       and make the inference connecting with Google's GPU.
     documentation: https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/README.md
-    links: [FRUNet2DsEVSegmentation]
+    links: [deepimagej/FRUNet2DsEVSegmentation]
     name: Small extracellular vesicle instance segmentation (FRU-Net)
     source: https://raw.githubusercontent.com/BIIG-UC3M/FRU-Net-TEM-segmentation/master/FRUnet_TEM_Exosomes_sEV.ipynb
     tags: [extracellular-vesicles, segmentation, TEM, notebook, model-inference, google-colab,
       workflow, pipeline]
     type: application
   status: pending
-  version_id: master
+  version_id: BIIG-UC3M/FRU-Net-TEM-segmentation/master

--- a/collection/deepimagej/FRUNet2DsEVSegmentation/resource.yaml
+++ b/collection/deepimagej/FRUNet2DsEVSegmentation/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/FRUNet2DsEVSegmentation
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:47.588685
+- created: '2021-12-26T23:54:48.007112'
   download_url: https://sandbox.zenodo.org/record/894459/files/deepimagej_fru-net_sev_segmentation.zip
   links: [deepimagej, EVsTEMsegmentationFRUNet, imjoy/BioImageIO-Packager]
   name: Small Extracellular Vesicle TEM Segmentation (Fully Residual U-Net)
   source: https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:09.434909
-  download_url: https://sandbox.zenodo.org/record/894459/files/deepimagej_fru-net_sev_segmentation.zip
-  links: [deepimagej, EVsTEMsegmentationFRUNet, imjoy/BioImageIO-Packager]
-  name: Small Extracellular Vesicle TEM Segmentation (Fully Residual U-Net)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/JonesVirtualStaining/resource.yaml
+++ b/collection/deepimagej/JonesVirtualStaining/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/JonesVirtualStaining
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:49.993700
+- created: '2021-12-26T23:54:50.358392'
   download_url: https://sandbox.zenodo.org/record/906803/files/bioimage.io.model.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Jones Virtual Staining (GAN)
   source: https://raw.githubusercontent.com/deepimagej/models/master/jones_virtual_staining/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:15.395883
-  download_url: https://sandbox.zenodo.org/record/906803/files/bioimage.io.model.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Jones Virtual Staining (GAN)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/jones_virtual_staining/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/MU-Lux_CTC_PhC-C2DL-PSC/resource.yaml
+++ b/collection/deepimagej/MU-Lux_CTC_PhC-C2DL-PSC/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/MU-Lux_CTC_PhC-C2DL-PSC
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:49.191619
+- created: '2021-12-26T23:54:49.503179'
   download_url: https://sandbox.zenodo.org/record/914413/files/mu-lux_ctc_phc-c2dl-psc.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Pancreatic Cell Phase Contrast Segmentation (DeepWater - CTC submission)
   source: https://raw.githubusercontent.com/deepimagej/models/master/mu-lux_ctc_phc-c2dl-psc/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:13.222797
-  download_url: https://sandbox.zenodo.org/record/914413/files/mu-lux_ctc_phc-c2dl-psc.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Pancreatic Cell Phase Contrast Segmentation (DeepWater - CTC submission)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/mu-lux_ctc_phc-c2dl-psc/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/MoNuSeg_digital_pathology_miccai2018/resource.yaml
+++ b/collection/deepimagej/MoNuSeg_digital_pathology_miccai2018/resource.yaml
@@ -2,7 +2,7 @@ id: deepimagej/MoNuSeg_digital_pathology_miccai2018
 status: pending
 type: dataset
 versions:
-- created: 2021-12-26 19:33:51.404725
+- created: '2021-12-26T23:42:27.547343'
   name: Multi-Organ Nucleus Segmentation Challenge - MICCAI 2018
   source:
     authors:
@@ -20,5 +20,6 @@ versions:
     source: https://monuseg.grand-challenge.org/Data/
     tags: [StarDist, segmentation, pathology, H&E, histology, 2D, nuclei segmentation,
       digital pathology]
+    type: dataset
   status: pending
   version_id: latest

--- a/collection/deepimagej/Mt3VirtualStaining/resource.yaml
+++ b/collection/deepimagej/Mt3VirtualStaining/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/Mt3VirtualStaining
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:50.198257
+- created: '2021-12-26T23:54:51.164433'
   download_url: https://sandbox.zenodo.org/record/906805/files/bioimage.io.model.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Masson’s Trichrome Virtual Staining (GAN)
   source: https://raw.githubusercontent.com/deepimagej/models/master/mt3_virtual_staining/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:15.874589
-  download_url: https://sandbox.zenodo.org/record/906805/files/bioimage.io.model.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Masson’s Trichrome Virtual Staining (GAN)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/mt3_virtual_staining/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/SMLMDensityMapEstimationDEFCoN/resource.yaml
+++ b/collection/deepimagej/SMLMDensityMapEstimationDEFCoN/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/SMLMDensityMapEstimationDEFCoN
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:48.568480
+- created: '2021-12-26T23:54:48.871394'
   download_url: https://zenodo.org/record/4608442/files/SMLM_Density%20Map_Estimation_%28DEFCoN%29.bioimage.io.model.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: SMLM Density Map Estimation (DEFCoN)
   source: https://raw.githubusercontent.com/deepimagej/models/master/defcon_density_map_estimation/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:11.699859
-  download_url: https://zenodo.org/record/4608442/files/SMLM_Density%20Map_Estimation_%28DEFCoN%29.bioimage.io.model.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: SMLM Density Map Estimation (DEFCoN)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/defcon_density_map_estimation/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/SkinLesionClassification/resource.yaml
+++ b/collection/deepimagej/SkinLesionClassification/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/SkinLesionClassification
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:50.603823
+- created: '2021-12-26T23:54:52.072958'
   download_url: https://sandbox.zenodo.org/record/906807/files/bioimage.io.model.zip
   links: [deepimagej]
   name: Skin lesions classification
   source: https://raw.githubusercontent.com/deepimagej/models/master/skin_lesion_classification/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:16.901225
-  download_url: https://sandbox.zenodo.org/record/906807/files/bioimage.io.model.zip
-  links: [deepimagej]
-  name: Skin lesions classification
-  source: https://raw.githubusercontent.com/deepimagej/models/master/skin_lesion_classification/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/Stardist2DZeroCostDL4Mic/resource.yaml
+++ b/collection/deepimagej/Stardist2DZeroCostDL4Mic/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/Stardist2DZeroCostDL4Mic
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:51.018355
+- created: '2021-12-26T23:54:52.992094'
   download_url: https://sandbox.zenodo.org/record/894493/files/MoNu_HE_StarDist_9JUL.bioimage.io.model.zip
   links: [deepimagej, zero/Notebook_StarDist_2D_ZeroCostDL4Mic_DeepImageJ, MoNuSeg_digital_pathology_miccai2018]
   name: Multi-Organ Nucleus Segmentation Challenge
   source: https://raw.githubusercontent.com/deepimagej/models/master/stardist2D_zerocostdl4mic/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:17.881354
-  download_url: https://sandbox.zenodo.org/record/894493/files/MoNu_HE_StarDist_9JUL.bioimage.io.model.zip
-  links: [deepimagej, zero/Notebook_StarDist_2D_ZeroCostDL4Mic_DeepImageJ, MoNuSeg_digital_pathology_miccai2018]
-  name: Multi-Organ Nucleus Segmentation Challenge
-  source: https://raw.githubusercontent.com/deepimagej/models/master/stardist2D_zerocostdl4mic/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/UNet2DGlioblastomaSegmentation/resource.yaml
+++ b/collection/deepimagej/UNet2DGlioblastomaSegmentation/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/UNet2DGlioblastomaSegmentation
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:48.358033
+- created: '2021-12-26T23:54:48.667143'
   download_url: https://zenodo.org/record/4155785/files/deepimagej_u-net_glioblastoma_segmentation.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Glioblastoma Phase Contrast Cell Segmentation (U-Net)
   source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_glioblastoma_segmentation/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:11.075121
-  download_url: https://zenodo.org/record/4155785/files/deepimagej_u-net_glioblastoma_segmentation.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Glioblastoma Phase Contrast Cell Segmentation (U-Net)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_glioblastoma_segmentation/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/UNet2DHeLaSegmentation/resource.yaml
+++ b/collection/deepimagej/UNet2DHeLaSegmentation/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/UNet2DHeLaSegmentation
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:47.809871
+- created: '2021-12-26T23:54:48.238769'
   download_url: https://sandbox.zenodo.org/record/913978/files/u-net_hela_segmentation.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: HeLa DIC Cell Segmentation (U-Net)
   source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_hela_segmentation/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:09.958872
-  download_url: https://sandbox.zenodo.org/record/913978/files/u-net_hela_segmentation.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: HeLa DIC Cell Segmentation (U-Net)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_hela_segmentation/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/UNet2DPancreaticSegmentation/resource.yaml
+++ b/collection/deepimagej/UNet2DPancreaticSegmentation/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/UNet2DPancreaticSegmentation
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:48.145544
+- created: '2021-12-26T23:54:48.461024'
   download_url: https://github.com/deepimagej/models/releases/download/0.3/PancreaticCellSegmentation.U-Net.bioimage.io.model.zip
   links: [deepimagej, unet-pancreaticcellsegmentation, imjoy/BioImageIO-Packager]
   name: Pancreatic Cell Segmentation (U-Net)
   source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:10.471670
-  download_url: https://github.com/deepimagej/models/releases/download/0.3/PancreaticCellSegmentation.U-Net.bioimage.io.model.zip
-  links: [deepimagej, unet-pancreaticcellsegmentation, imjoy/BioImageIO-Packager]
-  name: Pancreatic Cell Segmentation (U-Net)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/Usiigaci/resource.yaml
+++ b/collection/deepimagej/Usiigaci/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/Usiigaci
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:50.403138
+- created: '2021-12-26T23:54:51.657540'
   download_url: https://zenodo.org/record/4155785/files/usiigaci.bioimage.io.model.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: NIH/3T3 Fibroblast Phase Contrast Segmentation (Usiigaci-Mask R-CNN)
   source: https://raw.githubusercontent.com/deepimagej/models/master/usiigaci/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:16.398038
-  download_url: https://zenodo.org/record/4155785/files/usiigaci.bioimage.io.model.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: NIH/3T3 Fibroblast Phase Contrast Segmentation (Usiigaci-Mask R-CNN)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/usiigaci/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/WidefieldDapiSuperResolution/resource.yaml
+++ b/collection/deepimagej/WidefieldDapiSuperResolution/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/WidefieldDapiSuperResolution
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:49.597656
+- created: '2021-12-26T23:54:49.900168'
   download_url: https://sandbox.zenodo.org/record/914422/files/widefield_dapi_super-resolution.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Widefield Super-resolution (GAN - DAPI)
   source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_dapi_super-resolution/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:14.238257
-  download_url: https://sandbox.zenodo.org/record/914422/files/widefield_dapi_super-resolution.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Widefield Super-resolution (GAN - DAPI)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_dapi_super-resolution/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/WidefieldFitcSuperResolution/resource.yaml
+++ b/collection/deepimagej/WidefieldFitcSuperResolution/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/WidefieldFitcSuperResolution
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:49.795278
+- created: '2021-12-26T23:54:50.135342'
   download_url: https://sandbox.zenodo.org/record/914425/files/widefield_fitc_super-resolution.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Widefield Super-resolution (GAN - FITC)
   source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_fitc_super-resolution/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:14.857638
-  download_url: https://sandbox.zenodo.org/record/914425/files/widefield_fitc_super-resolution.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Widefield Super-resolution (GAN - FITC)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_fitc_super-resolution/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/WidefieldTxredSuperResolution/resource.yaml
+++ b/collection/deepimagej/WidefieldTxredSuperResolution/resource.yaml
@@ -2,17 +2,10 @@ id: deepimagej/WidefieldTxredSuperResolution
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:49.399062
+- created: '2021-12-26T23:54:49.696931'
   download_url: https://sandbox.zenodo.org/record/913992/files/widefield_txred_super-resolution.zip
   links: [deepimagej, imjoy/BioImageIO-Packager]
   name: Widefield Super-resolution (GAN - TxRed)
   source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_txred_super-resolution/model.yaml
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-25 18:54:13.721907
-  download_url: https://sandbox.zenodo.org/record/913992/files/widefield_txred_super-resolution.zip
-  links: [deepimagej, imjoy/BioImageIO-Packager]
-  name: Widefield Super-resolution (GAN - TxRed)
-  source: https://raw.githubusercontent.com/deepimagej/models/master/widefield_txred_super-resolution/model.yaml
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/deepimagej/deepimagej-web/resource.yaml
+++ b/collection/deepimagej/deepimagej-web/resource.yaml
@@ -2,7 +2,7 @@ id: deepimagej/deepimagej-web
 status: pending
 type: application
 versions:
-- created: 2021-12-26 19:33:51.019938
+- created: '2021-12-26T23:42:26.933535'
   name: DeepImageJ
   source:
     authors:

--- a/collection/deepimagej/deepimagej/resource.yaml
+++ b/collection/deepimagej/deepimagej/resource.yaml
@@ -2,7 +2,5 @@ id: deepimagej/deepimagej
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:51.346442', name: deepimagej, source: 'https://raw.githubusercontent.com/deepimagej/models/master/src/deepimagej-app.imjoy.html',
-  status: pending, version_id: 081bf4da443cc28ba20826d2d6fea7856075787c}
-- {created: ! '2021-12-25 18:54:18.444109', name: deepimagej, source: 'https://raw.githubusercontent.com/deepimagej/models/master/src/deepimagej-app.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:53.391591', name: deepimagej, source: 'https://raw.githubusercontent.com/deepimagej/models/master/src/deepimagej-app.imjoy.html',
+  status: pending, version_id: deepimagej/models/master}

--- a/collection/deepimagej/smlm-deepimagej/resource.yaml
+++ b/collection/deepimagej/smlm-deepimagej/resource.yaml
@@ -2,7 +2,7 @@ id: deepimagej/smlm-deepimagej
 status: pending
 type: application
 versions:
-- created: 2021-12-26 19:33:51.391638
+- created: '2021-12-26T23:54:53.403265'
   name: SMLM-superresolution
   source:
     authors:
@@ -25,4 +25,4 @@ versions:
     tags: [deepimagej, smlm, macro, deepstorm, thunderstorm, workflow, pipeline, superresolution]
     type: application
   status: pending
-  version_id: master
+  version_id: deepimagej/imagej-macros/master

--- a/collection/deepimagej/unet-pancreaticcellsegmentation/resource.yaml
+++ b/collection/deepimagej/unet-pancreaticcellsegmentation/resource.yaml
@@ -2,7 +2,7 @@ id: deepimagej/unet-pancreaticcellsegmentation
 status: pending
 type: application
 versions:
-- created: 2021-12-26 19:33:51.378761
+- created: '2021-12-26T23:54:53.397331'
   name: 2D U-Net for binary segmentation
   source:
     authors:
@@ -20,35 +20,10 @@ versions:
     description: Easy example to define a 2D U-Net for segmentation with Keras and
       import it into DeepImageJ format
     documentation: https://github.com/miura/NEUBIAS_AnalystSchool2020/tree/master/Ignacio
-    links: [UNet2DPancreaticSegmentation]
+    links: [deepimagej/UNet2DPancreaticSegmentation]
     name: 2D U-Net for binary segmentation
     source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/U_Net_PhC_C2DL_PSC_segmentation.ipynb
     tags: [unet, segmentation, deepimagej, notebook, training, cell-segmentation]
     type: application
   status: pending
-  version_id: 081bf4da443cc28ba20826d2d6fea7856075787c
-- created: 2021-12-26 02:01:48.375816
-  name: 2D U-Net for binary segmentation
-  source:
-    authors:
-    - {affiliation: 'EPFL, UC3M', name: Ignacio Arganda-Carreras}
-    - {affiliation: 'EPFL, UC3M', name: DeepImageJ}
-    badges:
-    - {icon: 'https://colab.research.google.com/assets/colab-badge.svg', label: Open
-        in Colab, url: 'https://colab.research.google.com/github/deepimagej/models/blob/master/u-net_pancreatic_segmentation/U_Net_PhC_C2DL_PSC_segmentation.ipynb'}
-    cite:
-    - {doi: 'https://doi.org/10.1038/s41592-018-0261-2', text: 'Falk, T., Mai, D.,
-        Bensch, R. et al. U-Net: deep learning for cell counting, detection, and morphometry.
-        Nat Methods 16, 67–70 (2019).'}
-    covers: ['https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/notebook_intro.png',
-      'https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/usecase.png']
-    description: Easy example to define a 2D U-Net for segmentation with Keras and
-      import it into DeepImageJ format
-    documentation: https://github.com/miura/NEUBIAS_AnalystSchool2020/tree/master/Ignacio
-    links: [UNet2DPancreaticSegmentation]
-    name: 2D U-Net for binary segmentation
-    source: https://raw.githubusercontent.com/deepimagej/models/master/u-net_pancreatic_segmentation/U_Net_PhC_C2DL_PSC_segmentation.ipynb
-    tags: [unet, segmentation, deepimagej, notebook, training, cell-segmentation]
-    type: application
-  status: pending
-  version_id: master
+  version_id: deepimagej/models/master

--- a/collection/fiji/Fiji/resource.yaml
+++ b/collection/fiji/Fiji/resource.yaml
@@ -2,7 +2,7 @@ id: fiji/Fiji
 status: pending
 type: application
 versions:
-- created: 2021-12-26 19:33:51.764507
+- created: '2021-12-26T23:42:28.007257'
   name: Fiji
   source:
     authors: [Fiji community]
@@ -18,5 +18,6 @@ versions:
     passive: true
     source: https://fiji.sc/
     tags: [fiji, software]
+    type: application
   status: pending
   version_id: latest

--- a/collection/fiji/N2VSEMDemo/resource.yaml
+++ b/collection/fiji/N2VSEMDemo/resource.yaml
@@ -2,10 +2,10 @@ id: fiji/N2VSEMDemo
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:51.763492
+- created: '2021-12-26T23:54:54.321515'
   download_url: https://github.com/bioimage-io/fiji-bioimage-io/releases/download/0.3.1/n2v-sem-demo.zip
   links: [Fiji]
   name: N2V SEM Demo
   source: https://raw.githubusercontent.com/bioimage-io/fiji-bioimage-io/master/models/n2v-sem-demo/model.yaml
   status: pending
-  version_id: master
+  version_id: bioimage-io/fiji-bioimage-io/master

--- a/collection/hpa/HPA-Classification/resource.yaml
+++ b/collection/hpa/HPA-Classification/resource.yaml
@@ -2,5 +2,5 @@ id: hpa/HPA-Classification
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:54.829667', name: HPA-Classification, source: 'https://raw.githubusercontent.com/imjoy-team/imjoy-plugins/master/repository/HPA-Classification.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:55:01.581820', name: HPA-Classification, source: 'https://raw.githubusercontent.com/imjoy-team/imjoy-plugins/master/repository/HPA-Classification.imjoy.html',
+  status: pending, version_id: imjoy-team/imjoy-plugins/master}

--- a/collection/hpa/HPA-NTU_MiRA/resource.yaml
+++ b/collection/hpa/HPA-NTU_MiRA/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-NTU_MiRA
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.601036
+- created: '2021-12-26T23:42:31.690779'
   name: HPA-NTU_MiRA
   source:
     authors: [Kuan-Lun Tseng]
@@ -17,5 +17,6 @@ versions:
     license: MIT
     name: HPA-NTU_MiRA
     tags: [classification, resnet-34]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-One-More/resource.yaml
+++ b/collection/hpa/HPA-One-More/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-One-More
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.598006
+- created: '2021-12-26T23:42:31.667381'
   name: HPA-One More Layer Of Stacking
   source:
     authors: [Dmitry Buslov, Sergei Fironov, Alexander Kiselev, Dmytro Panchenko]
@@ -17,5 +17,6 @@ versions:
     license: MIT
     name: HPA-One More Layer Of Stacking
     tags: [bn-inception, classification, inception-v4, lightgbm, se-resnext-50, xception]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-Random-Walk/resource.yaml
+++ b/collection/hpa/HPA-Random-Walk/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-Random-Walk
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.602285
+- created: '2021-12-26T23:42:31.699687'
   name: HPA-Random Walk
   source:
     authors: [Zhifeng Gao, Cheng Ju, Xiaohan Yi, Hongdong Zheng]
@@ -17,5 +17,6 @@ versions:
     license: MIT
     name: HPA-Random Walk
     tags: [attention-gate, classification, resnet-18]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-WAIR/resource.yaml
+++ b/collection/hpa/HPA-WAIR/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-WAIR
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.591829
+- created: '2021-12-26T23:42:31.620940'
   name: HPA-WAIR
   source:
     authors: [Jun Lan]
@@ -18,5 +18,6 @@ versions:
     name: HPA-WAIR
     tags: [classification, densenet-121, densenet-169, ibn-densenet-121, opencv, scikit-learn,
       se-resnext-50, xception]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-bestfitting/resource.yaml
+++ b/collection/hpa/HPA-bestfitting/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-bestfitting
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.590355
+- created: '2021-12-26T23:42:31.607943'
   name: HPA-bestfitting
   source:
     authors: [Shubin Dai]
@@ -19,5 +19,6 @@ versions:
     license: MIT
     name: HPA-bestfitting
     tags: [classification, densenet-121, inception-v3, resnet-34, resnet-50]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-conv/resource.yaml
+++ b/collection/hpa/HPA-conv/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-conv
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.599705
+- created: '2021-12-26T23:42:31.682617'
   name: HPA-conv is all you need
   source:
     authors: [Xuan Cao, Runmin Wei, Yuanhao Wu, Xun Zhu]
@@ -17,5 +17,6 @@ versions:
     license: MIT
     name: HPA-conv is all you need
     tags: [classification, inception-v3, se-resnext-50, xception]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-pudae/resource.yaml
+++ b/collection/hpa/HPA-pudae/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-pudae
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.593579
+- created: '2021-12-26T23:42:31.630682'
   name: HPA-pudae
   source:
     authors: [Park Jinmo]
@@ -17,5 +17,6 @@ versions:
     license: BSD-2-Clause
     name: HPA-pudae
     tags: [classification, inception-v3, resnet-34, se-resnext-50]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-vpp/resource.yaml
+++ b/collection/hpa/HPA-vpp/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-vpp
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.596586
+- created: '2021-12-26T23:42:31.658655'
   name: HPA-vpp
   source:
     authors: [Yinzheng Gu, Chuanpeng Li, Jinbin Xie]
@@ -18,5 +18,6 @@ versions:
     license: MIT
     name: HPA-vpp
     tags: [classification, inception-v3, inception-v4, multilayer-perceptron, xception]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPA-wienerschnitzelgemeinschaft/resource.yaml
+++ b/collection/hpa/HPA-wienerschnitzelgemeinschaft/resource.yaml
@@ -2,7 +2,7 @@ id: hpa/HPA-wienerschnitzelgemeinschaft
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.595089
+- created: '2021-12-26T23:42:31.645550'
   name: HPA-wienerschnitzelgemeinschaft
   source:
     authors: [Shaikat Mahmood Galib, Christof Henkel, Kevin Hwang, Dmytro Poplavskiy,
@@ -19,5 +19,6 @@ versions:
     name: HPA-wienerschnitzelgemeinschaft
     tags: [airnet-50, airnext-50, cbam, classification, hill-climbing, inception-resnet-v2,
       inception-v3, preresnet-50, resnet-18, resnet-34, resnet-50, resnet-101, se-resnext-50]
+    type: model
   status: pending
   version_id: latest

--- a/collection/hpa/HPAShuffleNetV2/resource.yaml
+++ b/collection/hpa/HPAShuffleNetV2/resource.yaml
@@ -2,9 +2,9 @@ id: hpa/HPAShuffleNetV2
 status: pending
 type: model
 versions:
-- created: 2021-12-26 19:33:54.589365
+- created: '2021-12-26T23:55:00.943666'
   links: [HPA-Classification]
   name: HPA ShuffleNetV2
   source: https://raw.githubusercontent.com/bioimage-io/tfjs-bioimage-io/master/models/HPAShuffleNetV2/HPAShuffleNetV2.model.yaml
   status: pending
-  version_id: master
+  version_id: bioimage-io/tfjs-bioimage-io/master

--- a/collection/ilastik/covid_if_training_data/resource.yaml
+++ b/collection/ilastik/covid_if_training_data/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/covid_if_training_data
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.193672
+- created: '2021-12-26T23:42:30.953410'
   name: Covid-IF Training Data
   source:
     authors:
@@ -22,5 +22,5 @@ versions:
     tags: [high-content-imaging, fluorescence-light-microscopy, 2D, cells, nuclei,
       covid19, semantic-segmentation, instance-segmentation]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/cremi_training_data/resource.yaml
+++ b/collection/ilastik/cremi_training_data/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/cremi_training_data
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.195704
+- created: '2021-12-26T23:42:30.963961'
   name: 'CREMI: MICCAI Challenge on Circuit Reconstruction from Electron Microscopy
     Images'
   source:
@@ -24,5 +24,5 @@ versions:
     tags: [electron-microscopy, brain, neurons, instance-segmentation, cremi-challenge,
       3D]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/ilastik/resource.yaml
+++ b/collection/ilastik/ilastik/resource.yaml
@@ -2,5 +2,5 @@ id: ilastik/ilastik
 status: accepted
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:53.499740', name: ilastik, source: 'https://raw.githubusercontent.com/ilastik/bioimage-io-models/main/src/ilastik-app.imjoy.html',
-  status: pending, version_id: main}
+- {created: '2021-12-26T23:54:58.659268', name: ilastik, source: 'https://raw.githubusercontent.com/ilastik/bioimage-io-models/main/src/ilastik-app.imjoy.html',
+  status: accepted, version_id: ilastik/bioimage-io-models/main}

--- a/collection/ilastik/isbi2012_neuron_segmentation_challenge/resource.yaml
+++ b/collection/ilastik/isbi2012_neuron_segmentation_challenge/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/isbi2012_neuron_segmentation_challenge
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.198683
+- created: '2021-12-26T23:42:30.994184'
   name: 'ISBI Challenge: Segmentation of neuronal structures in EM stacks'
   source:
     authors:
@@ -19,5 +19,5 @@ versions:
     source: https://oc.embl.de/index.php/s/sXJzYVK0xEgowOz/download
     tags: [electron-microscopy, brain, neurons, instance-segmentation, 2D, isbi2012-challenge]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/livecell_dataset/resource.yaml
+++ b/collection/ilastik/livecell_dataset/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/livecell_dataset
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.200369
+- created: '2021-12-26T23:42:31.005555'
   name: LIVECell
   source:
     authors:
@@ -18,5 +18,5 @@ versions:
     source: https://sartorius-research.github.io/LIVECell/
     tags: [2D, transmission-light-microscopy, label-free, cells, instance-segmentation]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/mitoem_segmentation_challenge/resource.yaml
+++ b/collection/ilastik/mitoem_segmentation_challenge/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/mitoem_segmentation_challenge
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.201800
+- created: '2021-12-26T23:42:31.030964'
   name: 'MitoEM Challenge: Large-scale 3D Mitochondria Instance Segmentation'
   source:
     authors:
@@ -18,5 +18,5 @@ versions:
     source: https://mitoem.grand-challenge.org/
     tags: [mitochondria, electron-microscopy, 3D, mito-em-challenge, instance-segmentation]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/platynereis_em_training_data/resource.yaml
+++ b/collection/ilastik/platynereis_em_training_data/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/platynereis_em_training_data
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.203740
+- created: '2021-12-26T23:42:31.057816'
   name: Platynereis EM Traning Data
   source:
     authors:
@@ -21,5 +21,5 @@ versions:
     tags: [electron-microscopy, platynereis, cells, cilia, nuclei, instance-segmentation,
       3D]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/ilastik/stradist_dsb_training_data/resource.yaml
+++ b/collection/ilastik/stradist_dsb_training_data/resource.yaml
@@ -2,7 +2,7 @@ id: ilastik/stradist_dsb_training_data
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:54.197339
+- created: '2021-12-26T23:42:30.979267'
   name: DSB Nucleus Segmentation Training Data
   source:
     authors:
@@ -20,5 +20,5 @@ versions:
     tags: [nuclei, instance-segmentation, fluorescence-light-microscopy, dsb-challenge,
       2D]
     type: dataset
-  status: pending
+  status: accepted
   version_id: latest

--- a/collection/imjoy/BioImageIO-Packager/resource.yaml
+++ b/collection/imjoy/BioImageIO-Packager/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/BioImageIO-Packager
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.133372', name: BioImageIO-Packager, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/bioimageio-packager.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:55.052403', name: BioImageIO-Packager, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/bioimageio-packager.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/imjoy/CellPose/resource.yaml
+++ b/collection/imjoy/CellPose/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/CellPose
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:53.120080', name: CellPose, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/cellpose.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:57.828818', name: CellPose, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/cellpose.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/imjoy/ImJoy/resource.yaml
+++ b/collection/imjoy/ImJoy/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/ImJoy
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.375093', name: ImJoy, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imjoy-app.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:55.951247', name: ImJoy, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imjoy-app.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/imjoy/ImJoyFiddle/resource.yaml
+++ b/collection/imjoy/ImJoyFiddle/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/ImJoyFiddle
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.740679', name: ImJoyFiddle, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imjoy-fiddle.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:56.688444', name: ImJoyFiddle, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imjoy-fiddle.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/imjoy/ImageJ.JS/resource.yaml
+++ b/collection/imjoy/ImageJ.JS/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/ImageJ.JS
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.557002', name: ImageJ.JS, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imagej-js.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:56.357851', name: ImageJ.JS, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imagej-js.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/imjoy/LuCa-7color/resource.yaml
+++ b/collection/imjoy/LuCa-7color/resource.yaml
@@ -2,7 +2,7 @@ id: imjoy/LuCa-7color
 status: pending
 type: dataset
 versions:
-- created: 2021-12-26 19:33:53.121019
+- created: '2021-12-26T23:42:30.067337'
   name: LuCa-7color
   source:
     authors: [Perkin Elmer]
@@ -10,9 +10,10 @@ versions:
     description: Sample PerkinElmer Vectra QPTIFF files (c) PerkinElmer (http://www.perkinelmer.com)
     download_url: https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/perkinelmer/PKI_scans/LuCa-7color_Scan1.qptiff
     license: CC-BY 4.0
-    links: [vizarr]
+    links: [imjoy/vizarr]
     name: LuCa-7color
     source: https://viv-demo.storage.googleapis.com/LuCa-7color_Scan1/data.zarr/0
     tags: [OME-TIFF]
+    type: dataset
   status: pending
   version_id: latest

--- a/collection/imjoy/Notebook Preview/resource.yaml
+++ b/collection/imjoy/Notebook Preview/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/Notebook Preview
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.180352', name: Notebook Preview, source: 'https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:55.509414', name: Notebook Preview, source: 'https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html',
+  status: pending, version_id: bioimage-io/nbpreview/master}

--- a/collection/imjoy/vizarr/resource.yaml
+++ b/collection/imjoy/vizarr/resource.yaml
@@ -2,5 +2,5 @@ id: imjoy/vizarr
 status: pending
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:52.939571', name: vizarr, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/vizarr.imjoy.html',
-  status: pending, version_id: master}
+- {created: '2021-12-26T23:54:57.039561', name: vizarr, source: 'https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/vizarr.imjoy.html',
+  status: pending, version_id: imjoy-team/bioimage-io-models/master}

--- a/collection/zero/Dataset_CARE_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_CARE_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_CARE_2D_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.753668
+- created: '2021-12-26T23:42:20.720909'
   name: CARE (2D) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3713330
     name: CARE (2D) example training and test dataset - ZeroCostDL4Mic
     tags: [CARE, denoising, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_CARE_2D_coli_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_CARE_2D_coli_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_CARE_2D_coli_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.781562
+- created: '2021-12-26T23:42:20.851021'
   name: Escherichia coli nucleoid denoising dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5551112
     name: Escherichia coli nucleoid denoising dataset - DeepBacs
     tags: [Noise2Void, CARE, denoising, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_CARE_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_CARE_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_CARE_3D_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.755148
+- created: '2021-12-26T23:42:20.728385'
   name: CARE (3D) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3713337
     name: CARE (3D) example training and test dataset - ZeroCostDL4Mic
     tags: [CARE, denoising, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_CycleGAN_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_CycleGAN_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_CycleGAN_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.761007
+- created: '2021-12-26T23:42:20.750218'
   name: CycleGAN example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet]
@@ -17,5 +17,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3941884
     name: CycleGAN example training and test dataset - ZeroCostDL4Mic
     tags: [CycleGAN, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_Deep-STORM_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_Deep-STORM_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_Deep-STORM_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.758001
+- created: '2021-12-26T23:42:20.742344'
   name: Deep-STORM training and example dataset - ZeroCostDL4Mic
   source:
     authors: [Christophe Leterrier, Romain F. Laine]
@@ -18,5 +18,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3959089
     name: Deep-STORM training and example dataset - ZeroCostDL4Mic
     tags: [SMLM, Deep-STORM, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_Noise2Void_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_Noise2Void_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_Noise2Void_2D_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.749181
+- created: '2021-12-26T23:42:20.703843'
   name: Noise2Void (2D) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Aki Stubb, Guillaume Jacquemet, Johanna Ivaska]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3713315
     name: Noise2Void (2D) example training and test dataset - ZeroCostDL4Mic
     tags: [Noise2Void, denoising, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_Noise2Void_2D_subtilis_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_Noise2Void_2D_subtilis_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_Noise2Void_2D_subtilis_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.780349
+- created: '2021-12-26T23:42:20.842348'
   name: Bacillus subtilis denoising dataset - DeepBacs
   source:
     authors: [Mia Conduit, Séamus Holden]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5551135
     name: Bacillus subtilis denoising dataset - DeepBacs
     tags: [Noise2Void, denoising, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_Noise2Void_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_Noise2Void_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_Noise2Void_3D_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.750582
+- created: '2021-12-26T23:42:20.712147'
   name: Noise2Void (3D) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3713326
     name: Noise2Void (3D) example training and test dataset - ZeroCostDL4Mic
     tags: [Noise2Void, denoising, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.773816
+- created: '2021-12-26T23:42:20.804208'
   name: Noisy nuclei dataset.
   source:
     authors: [Guillaume Jacquemet]
@@ -22,5 +22,6 @@ versions:
     download_url: https://zenodo.org/record/5750174
     name: Noisy nuclei dataset.
     tags: [denoising, CARE, Noise2Void, DecoNoising, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_SplineDist_2D_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_SplineDist_2D_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_SplineDist_2D_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.779089
+- created: '2021-12-26T23:42:20.835038'
   name: Escherichia coli bright field segmentation dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5550935
     name: Escherichia coli bright field segmentation dataset - DeepBacs
     tags: [StarDist, segmentation, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_2D_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_StarDist_2D_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_2D_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.777856
+- created: '2021-12-26T23:42:20.827148'
   name: Mixed segmentation dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann, Mia Conduit, Séamus Holden, Pedro Matos
@@ -20,5 +20,6 @@ versions:
     download_url: https://zenodo.org/record/5551009
     name: Mixed segmentation dataset - DeepBacs
     tags: [StarDist, segmentation, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D/resource.yaml
+++ b/collection/zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.747955
+- created: '2021-12-26T23:42:20.696264'
   name: StarDist (2D) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Johanna Jukkala, Guillaume Jacquemet]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3715492
     name: StarDist (2D) example training and test dataset - ZeroCostDL4Mic
     tags: [StarDist, segmentation, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.768190
+- created: '2021-12-26T23:42:20.772408'
   name: Combining StarDist and TrackMate example 1 - Breast cancer cell dataset
   source:
     authors: [Guillaume Jacquemet]
@@ -21,5 +21,6 @@ versions:
     download_url: https://zenodo.org/record/4034976
     name: Combining StarDist and TrackMate example 1 - Breast cancer cell dataset
     tags: [StarDist, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.771341
+- created: '2021-12-26T23:42:20.788644'
   name: Combining StarDist and TrackMate example 3 - Flow chamber dataset
   source:
     authors: [Gautier Follain, Guillaume Jacquemet]
@@ -20,5 +20,6 @@ versions:
     download_url: https://zenodo.org/record/4034939
     name: Combining StarDist and TrackMate example 3 - Flow chamber dataset
     tags: [StarDist, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.769603
+- created: '2021-12-26T23:42:20.779450'
   name: Combining StarDist and TrackMate example 2 - T cell dataset
   source:
     authors: [Nathan H. Roy, Guillaume Jacquemet]
@@ -21,5 +21,6 @@ versions:
     download_url: https://zenodo.org/record/4034929
     name: Combining StarDist and TrackMate example 2 - T cell dataset
     tags: [StarDist, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.772576
+- created: '2021-12-26T23:42:20.796678'
   name: training dataset for automated tracking of MDA-MB-231 and BT20 cells
   source:
     authors: [Hussein Al-Akhrass, Johanna Ivaska, Guillaume Jacquemet]
@@ -21,5 +21,6 @@ versions:
     download_url: https://zenodo.org/record/4811213
     name: training dataset for automated tracking of MDA-MB-231 and BT20 cells
     tags: [StarDist, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_U-Net_2D_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_U-Net_2D_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_U-Net_2D_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.776537
+- created: '2021-12-26T23:42:20.819526'
   name: Escherichia coli bright field segmentation dataset - DeepBacs
   source:
     authors: [Spahn Christoph, Heilemann Mike]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5550935
     name: Escherichia coli bright field segmentation dataset - DeepBacs
     tags: [U-Net, segmentation, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_U-Net_2D_multilabel_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_U-Net_2D_multilabel_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_U-Net_2D_multilabel_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.775103
+- created: '2021-12-26T23:42:20.811600'
   name: Multi-label U-Net training dataset (Bacillus subtilis) - DeepBacs
   source:
     authors: [Mia Conduit, Séamus Holden]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5639253
     name: Multi-label U-Net training dataset (Bacillus subtilis) - DeepBacs
     tags: [U-Net, multilabel, segmentation, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_YOLOv2_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_YOLOv2_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_YOLOv2_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.766817
+- created: '2021-12-26T23:42:20.765713'
   name: YoloV2 example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet, Lucas von Chamier]
@@ -17,5 +17,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3941908
     name: YoloV2 example training and test dataset - ZeroCostDL4Mic
     tags: [YOLOv2, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_YOLOv2_antibiotic_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_YOLOv2_antibiotic_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_YOLOv2_antibiotic_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.785213
+- created: '2021-12-26T23:42:20.875886'
   name: Escherichia coli antibiotic phenotyping object detection dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5551057
     name: Escherichia coli antibiotic phenotyping object detection dataset - DeepBacs
     tags: [YOLOv2, object detection, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_YOLOv2_coli_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_YOLOv2_coli_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_YOLOv2_coli_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.784064
+- created: '2021-12-26T23:42:20.867956'
   name: Escherichia coli growth stage object detection dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann]
@@ -19,5 +19,6 @@ versions:
     download_url: https://zenodo.org/record/5551016
     name: Escherichia coli growth stage object detection dataset - DeepBacs
     tags: [YOLOv2, object detection, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_fnet_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_fnet_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_fnet_3D_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.756673
+- created: '2021-12-26T23:42:20.735195'
   name: Label-free prediction (fnet) example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Christoph Spahn]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3748967
     name: Label-free prediction (fnet) example training and test dataset - ZeroCostDL4Mic
     tags: [fnet, labelling, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_fnet_DeepBacs/resource.yaml
+++ b/collection/zero/Dataset_fnet_DeepBacs/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_fnet_DeepBacs
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.782921
+- created: '2021-12-26T23:42:20.859384'
   name: Artificial labeling of E. coli membranes dataset - DeepBacs
   source:
     authors: [Christoph Spahn, Mike Heilemann]
@@ -20,5 +20,6 @@ versions:
     download_url: https://zenodo.org/record/5551123
     name: Artificial labeling of E. coli membranes dataset - DeepBacs
     tags: [fnet, CARE, artificial labelling, DeepBacs, 2D]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Dataset_pix2pix_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Dataset_pix2pix_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Dataset_pix2pix_ZeroCostDL4Mic
 status: accepted
 type: dataset
 versions:
-- created: 2021-12-26 19:33:46.764018
+- created: '2021-12-26T23:42:20.759056'
   name: pix2pix example training and test dataset - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet]
@@ -16,5 +16,6 @@ versions:
     download_url: https://doi.org/10.5281/zenodo.3941889
     name: pix2pix example training and test dataset - ZeroCostDL4Mic
     tags: [pix2pix, ZeroCostDL4Mic]
-  status: pending
+    type: dataset
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook Preview/resource.yaml
+++ b/collection/zero/Notebook Preview/resource.yaml
@@ -2,7 +2,5 @@ id: zero/Notebook Preview
 status: accepted
 type: application
 versions:
-- {created: ! '2021-12-26 19:33:46.692598', name: Notebook Preview, source: 'https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html',
-  status: pending, version_id: 2a07751974f450d5f536879c1851816c95f66ac8}
-- {created: ! '2021-12-25 18:54:07.811410', name: Notebook Preview, source: 'https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html',
-  status: accepted, version_id: master}
+- {created: '2021-12-26T23:54:47.436310', name: Notebook Preview, source: 'https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html',
+  status: accepted, version_id: bioimage-io/nbpreview/master}

--- a/collection/zero/Notebook_Augmentor_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Augmentor_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Augmentor_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.715037
+- created: '2021-12-26T23:42:20.446872'
   name: Augmentor - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -28,8 +28,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Tools/Augmentor_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: Augmentor - ZeroCostDL4Mic
     tags: [colab, notebook, Augmentor, Data Augmentation, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_CARE_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_CARE_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_CARE_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.704078
+- created: '2021-12-26T23:42:20.394498'
   name: CARE (2D) - ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -31,9 +31,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/CARE_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_CARE_2D_ZeroCostDL4Mic, Dataset_Noisy_Nuclei_ZeroCostDL4Mic,
-      Dataset_CARE_2D_coli_DeepBacs, Dataset_fnet_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_CARE_2D_ZeroCostDL4Mic, zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic,
+      zero/Dataset_CARE_2D_coli_DeepBacs, zero/Dataset_fnet_DeepBacs]
     name: CARE (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, CARE, denoising, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_CARE_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_CARE_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_CARE_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.705905
+- created: '2021-12-26T23:42:20.401047'
   name: CARE (3D) - ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -29,8 +29,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/CARE_3D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_CARE_3D_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_CARE_3D_ZeroCostDL4Mic]
     name: CARE (3D) - ZeroCostDL4Mic
     tags: [colab, notebook, CARE, denoising, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Cellpose_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Cellpose_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Cellpose_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.734228
+- created: '2021-12-26T23:42:20.599589'
   name: Cellpose (2D and 3D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -26,10 +26,11 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/Cellpose_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_StarDist_2D_ZeroCostDL4Mic_2D, Dataset_StarDist_Fluo_ZeroCostDL4Mic,
-      Dataset_StarDist_brightfield_ZeroCostDL4Mic, Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
-      Dataset_StarDist_fluo2_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D, zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic, zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic]
     name: Cellpose (2D and 3D) - ZeroCostDL4Mic
     tags: [colab, notebook, Cellpose, Segmentation, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_CycleGAN_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_CycleGAN_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_CycleGAN_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.713728
+- created: '2021-12-26T23:42:20.439885'
   name: CycleGAN (2D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -29,8 +29,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/CycleGAN_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_CycleGAN_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_CycleGAN_ZeroCostDL4Mic]
     name: CycleGAN (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, CycleGAN, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_DFCAN_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_DFCAN_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_DFCAN_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.744901
+- created: '2021-12-26T23:42:20.674221'
   name: DFCAN - ZeroCostDL4Mic
   source:
     authors: ['Ainhoa Serrano, Ignacio Arganda-Carreras and the ZeroCostDL4Mic Team']
@@ -28,8 +28,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/DFCAN_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: DFCAN - ZeroCostDL4Mic
     tags: [colab, notebook, DFCAN, Super Resolution, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_DRMIME_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_DRMIME_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_DRMIME_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.732741
+- created: '2021-12-26T23:42:20.590164'
   name: DRMIME - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -24,8 +24,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/DRMIME_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: DRMIME - ZeroCostDL4Mic
     tags: [colab, notebook, DRMIME, image registration, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_DecoNoising_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_DecoNoising_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_DecoNoising_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.738421
+- created: '2021-12-26T23:42:20.625847'
   name: DecoNoising (2D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -25,9 +25,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/DecoNoising_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_Noise2Void_2D_ZeroCostDL4Mic, Dataset_Noise2Void_2D_subtilis_DeepBacs,
-      Dataset_Noisy_Nuclei_ZeroCostDL4Mic, Dataset_CARE_2D_coli_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_Noise2Void_2D_ZeroCostDL4Mic, zero/Dataset_Noise2Void_2D_subtilis_DeepBacs,
+      zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic, zero/Dataset_CARE_2D_coli_DeepBacs]
     name: DecoNoising (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, DecoNoising, denoising, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.710469
+- created: '2021-12-26T23:42:20.425933'
   name: Deep-STORM (2D) - ZeroCostDL4Mic
   source:
     authors: [Romain Laine and the ZeroCostDL4Mic Team]
@@ -33,8 +33,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Deep-STORM_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_Deep-STORM_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_Deep-STORM_ZeroCostDL4Mic]
     name: Deep-STORM (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, Deep-STORM, labelling, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
+++ b/collection/zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Deep-STORM_2D_ZeroCostDL4Mic_DeepImageJ
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.718157
+- created: '2021-12-26T23:42:20.463171'
   name: Deep-STORM (2D) - ZeroCostDL4Mic - DeepImageJ
   source:
     authors: [Estibaliz Gómez de Mariscal and the deepImageJ and the ZeroCostDL4Mic
@@ -35,8 +35,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/BioImage.io%20notebooks/Deep-STORM_2D_ZeroCostDL4Mic_BioImageModelZoo_export.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_Deep-STORM_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_Deep-STORM_ZeroCostDL4Mic]
     name: Deep-STORM (2D) - ZeroCostDL4Mic - DeepImageJ
     tags: [colab, notebook, Deep-STORM, DeepImageJ, ZeroCostDL4Mic, 2D, deepImageJ]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_DenoiSeg_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_DenoiSeg_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_DenoiSeg_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.716707
+- created: '2021-12-26T23:42:20.455503'
   name: DenoiSeg (2D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -29,8 +29,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/DenoiSeg_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: DenoiSeg (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, CycleGAN, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Detectron2_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Detectron2_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Detectron2_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.731321
+- created: '2021-12-26T23:42:20.578632'
   name: Detectron2 - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -24,9 +24,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/Detectron2_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_YOLOv2_ZeroCostDL4Mic, Dataset_YOLOv2_coli_DeepBacs,
-      Dataset_YOLOv2_antibiotic_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_YOLOv2_ZeroCostDL4Mic, zero/Dataset_YOLOv2_coli_DeepBacs,
+      zero/Dataset_YOLOv2_antibiotic_DeepBacs]
     name: Detectron2 - ZeroCostDL4Mic
     tags: [colab, notebook, Detectron2, object detection, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_EmbedSeg_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_EmbedSeg_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_EmbedSeg_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.746374
+- created: '2021-12-26T23:42:20.685688'
   name: EmbedSeg (2D) - ZeroCostDL4Mic
   source:
     authors: ['Amin Rezaei, Guillaume Jacquemet and the ZeroCostDL4Mic Team']
@@ -22,10 +22,11 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/EmbedSeg_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_StarDist_2D_ZeroCostDL4Mic_2D, Dataset_StarDist_Fluo_ZeroCostDL4Mic,
-      Dataset_StarDist_brightfield_ZeroCostDL4Mic, Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
-      Dataset_StarDist_fluo2_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D, zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic, zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic]
     name: EmbedSeg (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, EmbedSeg, Segmentation, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Interactive_Segmentation_Kaibu_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Interactive_Segmentation_Kaibu_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Interactive_Segmentation_Kaibu_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.740010
+- created: '2021-12-26T23:42:20.640714'
   name: Interactive Segmentation - Kaibu (2D) - ZeroCostDL4Mic
   source:
     authors: ['Romain Laine, Wei Ouyang and the ZeroCostDL4Mic Team']
@@ -26,8 +26,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/ZeroCostDL4Mic_Interactive_annotations_Cellpose.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: Interactive Segmentation - Kaibu (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, Cellpose, Segmentation, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_MaskRCNN_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_MaskRCNN_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_MaskRCNN_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.741647
+- created: '2021-12-26T23:42:20.652008'
   name: MaskRCNN - ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -22,8 +22,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/MaskRCNN_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: MaskRCNN - ZeroCostDL4Mic
     tags: [colab, notebook, MaskRCNN, object detection, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Noise2Void_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Noise2Void_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Noise2Void_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.700546
+- created: '2021-12-26T23:42:20.376155'
   name: Noise2Void (2D) - ZeroCostDL4Mic
   source:
     authors: [Romain Laine and the ZeroCostDL4Mic Team]
@@ -27,9 +27,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Noise2Void_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_Noise2Void_2D_ZeroCostDL4Mic, Dataset_Noise2Void_2D_subtilis_DeepBacs,
-      Dataset_Noisy_Nuclei_ZeroCostDL4Mic, Dataset_CARE_2D_coli_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_Noise2Void_2D_ZeroCostDL4Mic, zero/Dataset_Noise2Void_2D_subtilis_DeepBacs,
+      zero/Dataset_Noisy_Nuclei_ZeroCostDL4Mic, zero/Dataset_CARE_2D_coli_DeepBacs]
     name: Noise2Void (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, Noise2Void, denoising, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Noise2Void_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Noise2Void_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Noise2Void_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.702095
+- created: '2021-12-26T23:42:20.385253'
   name: Noise2VOID (3D) - ZeroCostDL4Mic
   source:
     authors: [Romain Laine and the ZeroCostDL4Mic Team]
@@ -27,8 +27,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Noise2Void_3D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_Noise2Void_3D_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_Noise2Void_3D_ZeroCostDL4Mic]
     name: Noise2VOID (3D) - ZeroCostDL4Mic
     tags: [colab, notebook, Noise2Void, denoising, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_Quality_Control_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_Quality_Control_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_Quality_Control_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.743428
+- created: '2021-12-26T23:42:20.664346'
   name: Quality Control - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -21,8 +21,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Tools/Quality_Control_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: Quality Control - ZeroCostDL4Mic
     tags: [colab, notebook, Quality Control, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_RCAN_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_RCAN_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_RCAN_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.726694
+- created: '2021-12-26T23:42:20.510058'
   name: RCAN (3D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -29,8 +29,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/3D-RCAN_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_CARE_3D_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_CARE_3D_ZeroCostDL4Mic]
     name: RCAN (3D) - ZeroCostDL4Mic
     tags: [colab, notebook, 3D-RCAN, denoising, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_RetinaNet_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_RetinaNet_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_RetinaNet_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.736260
+- created: '2021-12-26T23:42:20.611794'
   name: RetinaNet - ZeroCostDL4Mic
   source:
     authors: ['Erlantz Calvo, Ignacio Arganda-Carreras and the ZeroCostDL4Mic Team']
@@ -24,9 +24,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/RetinaNet_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_YOLOv2_ZeroCostDL4Mic, Dataset_YOLOv2_coli_DeepBacs,
-      Dataset_YOLOv2_antibiotic_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_YOLOv2_ZeroCostDL4Mic, zero/Dataset_YOLOv2_coli_DeepBacs,
+      zero/Dataset_YOLOv2_antibiotic_DeepBacs]
     name: RetinaNet - ZeroCostDL4Mic
     tags: [colab, notebook, RetinaNet, object detection, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_SplineDist_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_SplineDist_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_SplineDist_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.728550
+- created: '2021-12-26T23:42:20.519703'
   name: SplineDist (2D) - ZeroCostDL4Mic
   source:
     authors: [Romain F. Laine and the ZeroCostDL4Mic Team]
@@ -26,10 +26,12 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Beta%20notebooks/SplineDist_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_StarDist_2D_ZeroCostDL4Mic_2D, Dataset_StarDist_Fluo_ZeroCostDL4Mic,
-      Dataset_StarDist_brightfield_ZeroCostDL4Mic, Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
-      Dataset_StarDist_fluo2_ZeroCostDL4Mic, Dataset_StarDist_2D_DeepBacs, Dataset_SplineDist_2D_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D, zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic, zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic, zero/Dataset_StarDist_2D_DeepBacs,
+      zero/Dataset_SplineDist_2D_DeepBacs]
     name: SplineDist (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, SplineDist, segmentation, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_StarDist_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_StarDist_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_StarDist_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.697335
+- created: '2021-12-26T23:42:20.355121'
   name: StarDist (2D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -27,10 +27,11 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/StarDist_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_StarDist_2D_ZeroCostDL4Mic_2D, Dataset_StarDist_Fluo_ZeroCostDL4Mic,
-      Dataset_StarDist_brightfield_ZeroCostDL4Mic, Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
-      Dataset_StarDist_fluo2_ZeroCostDL4Mic, Dataset_StarDist_2D_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D, zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic, zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic, zero/Dataset_StarDist_2D_DeepBacs]
     name: StarDist (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, StarDist, segmentation, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_StarDist_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
+++ b/collection/zero/Notebook_StarDist_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_StarDist_2D_ZeroCostDL4Mic_DeepImageJ
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.724859
+- created: '2021-12-26T23:42:20.496583'
   name: StarDist (2D) - ZeroCostDL4Mic - DeepImageJ
   source:
     authors: [Estibaliz Gómez de Mariscal and the deepImageJ and the ZeroCostDL4Mic
@@ -29,10 +29,11 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/BioImage.io%20notebooks/StarDist_2D_ZeroCostDL4Mic_BioImageModelZoo_export.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_StarDist_2D_ZeroCostDL4Mic_2D, Dataset_StarDist_Fluo_ZeroCostDL4Mic,
-      Dataset_StarDist_brightfield_ZeroCostDL4Mic, Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
-      Dataset_StarDist_fluo2_ZeroCostDL4Mic, Dataset_StarDist_2D_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_StarDist_2D_ZeroCostDL4Mic_2D, zero/Dataset_StarDist_Fluo_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_brightfield_ZeroCostDL4Mic, zero/Dataset_StarDist_brightfield2_ZeroCostDL4Mic,
+      zero/Dataset_StarDist_fluo2_ZeroCostDL4Mic, zero/Dataset_StarDist_2D_DeepBacs]
     name: StarDist (2D) - ZeroCostDL4Mic - DeepImageJ
     tags: [colab, notebook, StarDist, segmentation, ZeroCostDL4Mic, 2D, deepimagej]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_StarDist_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_StarDist_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_StarDist_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.699033
+- created: '2021-12-26T23:42:20.367301'
   name: StarDist (3D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -24,8 +24,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/StarDist_3D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: StarDist (3D) - ZeroCostDL4Mic
     tags: [colab, notebook, StarDist, segmentation, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_U-Net_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_U-Net_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_U-Net_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.693727
+- created: '2021-12-26T23:42:20.334952'
   name: U-Net (2D) - ZeroCostDL4Mic
   source:
     authors: [Romain Laine and the ZeroCostDL4Mic Team]
@@ -27,8 +27,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/U-Net_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_U-Net_2D_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_U-Net_2D_DeepBacs]
     name: U-Net (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, U-Net, segmentation, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_U-Net_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
+++ b/collection/zero/Notebook_U-Net_2D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_U-Net_2D_ZeroCostDL4Mic_DeepImageJ
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.721587
+- created: '2021-12-26T23:42:20.477045'
   name: U-Net (2D) - ZeroCostDL4Mic - DeepImageJ
   source:
     authors: [Estibaliz Gómez de Mariscal and the deepImageJ and the ZeroCostDL4Mic
@@ -29,8 +29,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/BioImage.io%20notebooks/U-Net_2D_ZeroCostDL4Mic_BioImageModelZoo_export.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: U-Net (2D) - ZeroCostDL4Mic - DeepImageJ
     tags: [colab, notebook, U-Net, segmentation, ZeroCostDL4Mic, 2D, deepimagej]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_U-Net_2D_multilabel_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_U-Net_2D_multilabel_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_U-Net_2D_multilabel_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.723095
+- created: '2021-12-26T23:42:20.486102'
   name: U-Net (2D) multilabel segmentation - ZeroCostDL4Mic
   source:
     authors: [Estibaliz Gómez de Mariscal and the ZeroCostDL4Mic teams]
@@ -28,9 +28,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://github.com/HenriquesLab/ZeroCostDL4Mic/blob/master/Colab_notebooks/Beta%20notebooks/U-Net_2D_Multilabel_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_U-Net_2D_multilabel_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_U-Net_2D_multilabel_DeepBacs]
     name: U-Net (2D) multilabel segmentation - ZeroCostDL4Mic
     tags: [colab, notebook, u-net, segmentation, semantic-segmentation, multilabel,
       ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_U-Net_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_U-Net_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_U-Net_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.695852
+- created: '2021-12-26T23:42:20.345497'
   name: U-Net (3D) - ZeroCostDL4Mic
   source:
     authors: [Daniel Krentzel and the ZeroCostDL4Mic Team]
@@ -25,8 +25,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/U-Net_3D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: U-Net (3D) - ZeroCostDL4Mic
     tags: [colab, notebook, U-Net, segmentation, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_U-Net_3D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
+++ b/collection/zero/Notebook_U-Net_3D_ZeroCostDL4Mic_DeepImageJ/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_U-Net_3D_ZeroCostDL4Mic_DeepImageJ
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.720117
+- created: '2021-12-26T23:42:20.470534'
   name: U-Net (3D) - ZeroCostDL4Mic - DeepImageJ
   source:
     authors: [Estibaliz Gómez de Mariscal and the deepImageJ and the ZeroCostDL4Mic
@@ -27,8 +27,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/BioImage.io%20notebooks/U-Net_3D_ZeroCostDL4Mic_BioImageModelZoo_export.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview]
+    links: [zero/Notebook Preview]
     name: U-Net (3D) - ZeroCostDL4Mic - DeepImageJ
     tags: [colab, notebook, U-Net, segmentation, ZeroCostDL4Mic, 3D, deepimagej]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_YOLOv2_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_YOLOv2_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_YOLOv2_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.729952
+- created: '2021-12-26T23:42:20.529246'
   name: YOLOv2 - ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -24,9 +24,10 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/YOLOv2_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_YOLOv2_ZeroCostDL4Mic, Dataset_YOLOv2_coli_DeepBacs,
-      Dataset_YOLOv2_antibiotic_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_YOLOv2_ZeroCostDL4Mic, zero/Dataset_YOLOv2_coli_DeepBacs,
+      zero/Dataset_YOLOv2_antibiotic_DeepBacs]
     name: YOLOv2 - ZeroCostDL4Mic
     tags: [colab, notebook, YOLOv2, object detection, ZeroCostDL4Mic]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_fnet_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_fnet_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_fnet_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.709064
+- created: '2021-12-26T23:42:20.419358'
   name: Label-free Prediction - fnet - (2D) ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -30,8 +30,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/fnet_2D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_fnet_DeepBacs]
+    links: [zero/Notebook Preview, zero/Dataset_fnet_DeepBacs]
     name: Label-free Prediction - fnet - (2D) ZeroCostDL4Mic
     tags: [colab, notebook, fnet, labelling, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_fnet_3D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_fnet_3D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_fnet_3D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.707340
+- created: '2021-12-26T23:42:20.410172'
   name: Label-free Prediction - fnet - (3D) ZeroCostDL4Mic
   source:
     authors: [Lucas von Chamier and the ZeroCostDL4Mic Team]
@@ -30,8 +30,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/fnet_3D_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_fnet_3D_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_fnet_3D_ZeroCostDL4Mic]
     name: Label-free Prediction - fnet - (3D) ZeroCostDL4Mic
     tags: [colab, notebook, fnet, labelling, ZeroCostDL4Mic, 3D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest

--- a/collection/zero/Notebook_pix2pix_2D_ZeroCostDL4Mic/resource.yaml
+++ b/collection/zero/Notebook_pix2pix_2D_ZeroCostDL4Mic/resource.yaml
@@ -2,7 +2,7 @@ id: zero/Notebook_pix2pix_2D_ZeroCostDL4Mic
 status: accepted
 type: application
 versions:
-- created: 2021-12-26 19:33:46.712320
+- created: '2021-12-26T23:42:20.434765'
   name: pix2pix (2D) - ZeroCostDL4Mic
   source:
     authors: [Guillaume Jacquemet and the ZeroCostDL4Mic Team]
@@ -27,8 +27,9 @@ versions:
     documentation: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/BioimageModelZoo/README.md
     download_url: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/pix2pix_ZeroCostDL4Mic.ipynb
     git_repo: https://github.com/HenriquesLab/ZeroCostDL4Mic
-    links: [Notebook Preview, Dataset_pix2pix_ZeroCostDL4Mic]
+    links: [zero/Notebook Preview, zero/Dataset_pix2pix_ZeroCostDL4Mic]
     name: pix2pix (2D) - ZeroCostDL4Mic
     tags: [colab, notebook, pix2pix, ZeroCostDL4Mic, 2D]
-  status: pending
+    type: application
+  status: accepted
   version_id: latest


### PR DESCRIPTION
This PR fixes the collection generation script by pulling information directly from the source. 

The newly generated summary will be directly deployed to gh-pages branch so we can directly render a preview link from the website in the future.

This PR also removes the part which calls github api to obtain version tag, this is because of the rate limit error. I think we can extract the version id directly from the github source url.  

Closes https://github.com/bioimage-io/collection-bioimage-io/issues/121