### PR TITLE
Split workflow on main and add  workflow_dispatch event

### DIFF
--- a/.github/workflows/auto_update_main.yaml
+++ b/.github/workflows/auto_update_main.yaml
@@ -6,24 +6,9 @@ on:
     branches: [ main ]
   schedule:
     - cron:  '0 1,13 * * *'
+  workflow_dispatch: # triggered by http endpoints
 
 jobs:
-  build-collection:  # deploy collection rdf to gh-pages
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: install script deps
-      run: pip install typer ruamel.yaml bioimageio.spec boltons lxml requests
-    - name: generate collection rdf
-      run: python scripts/generate_collection_rdf.py
-    - name: Deploy collection rdf to gh-pages 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.4
-      with:
-        clean: false
-        branch: gh-pages
-        folder: dist/gh-pages
-
   collect-new-resources:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build_collection_main.yaml
+++ b/.github/workflows/build_collection_main.yaml
@@ -1,0 +1,22 @@
+name: build-collection
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-collection:  # deploy collection rdf to gh-pages
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install script deps
+      run: pip install typer ruamel.yaml bioimageio.spec boltons lxml requests
+    - name: generate collection rdf
+      run: python scripts/generate_collection_rdf.py
+    - name: Deploy collection rdf to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        clean: false
+        branch: gh-pages
+        folder: dist/gh-pages

--- a/.github/workflows/build_collection_main.yaml
+++ b/.github/workflows/build_collection_main.yaml
@@ -3,6 +3,7 @@ name: build-collection
 on:
   push:
     branches: [ main ]
+  workflow_dispatch: # triggered by http endpoints
 
 jobs:
   build-collection:  # deploy collection rdf to gh-pages


### PR DESCRIPTION
This PR split the workflow on the main branch into 1) a workflow that detect new resources  (also as a cron job) 2) another workflow that build the collection rdf for the website only runs if pushed to main.