### PR TITLE
increase max auto prs to 50

### DIFF
--- a/.github/workflows/auto_update_main.yaml
+++ b/.github/workflows/auto_update_main.yaml
@@ -21,7 +21,7 @@ jobs:
       run: pip install bioimageio.spec PyGithub lxml
     - name: update known resources
       id: update_known
-      run: python scripts/update_known_resources.py collection 5
+      run: python scripts/update_known_resources.py collection 50
     - name: "Upload updated collection"
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
with a limit on the auto prs we have to resolve any current ones to be able to merge "invisibly" pending ones. For some it might take a while to get accepted. Therefore a highger number of concurrent auto-PRs is needed in order not to have to block resources just to get to the invisible ones...