### PR TITLE
Remove timezone info

### DIFF
--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -125,7 +125,7 @@ def update_from_zenodo(
         for hit in hits:
             resource_doi = hit["conceptdoi"]
             doi = hit["doi"]  # "version" doi
-            created = datetime.fromisoformat(hit["created"])
+            created = datetime.fromisoformat(hit["created"]).replace(tzinfo=None)
             assert isinstance(created, datetime), created
             resource_path = collection_dir / resource_doi / "resource.yaml"
             version_name = f"revision {hit['revision']}"


### PR DESCRIPTION
This PR fixes the issue of comparing created date of zenodo versions:

```
can't compare offset-naive and offset-aware datetimes
  File "/Users/weiouyang/workspace/collection-bioimage-io/scripts/update_known_resources.py", line 71, in write_resource
    resource["versions"].sort(key=lambda v: v["created"], reverse=True)
  File "/Users/weiouyang/workspace/collection-bioimage-io/scripts/update_known_resources.py", line 159, in update_from_zenodo
    resource = write_resource(
  File "/Users/weiouyang/workspace/collection-bioimage-io/scripts/update_known_resources.py", line 175, in main
    update_from_zenodo(collection_dir, updated_resources)
  File "/Users/weiouyang/workspace/collection-bioimage-io/scripts/update_known_resources.py", line 226, in <module>
    typer.run(main)
```

cc @FynnBe I just remove the timezone info for now, please take a closer look see if this is the right fix.