### PR TITLE
Do not block resource automatically

### DIFF
--- a/collection/10.5281/zenodo.5817052/resource.yaml
+++ b/collection/10.5281/zenodo.5817052/resource.yaml
@@ -1,6 +1,6 @@
 doi: 10.5281/zenodo.5817052
 id: 10.5281/zenodo.5817052
-status: blocked
+status: accepted
 type: model
 versions:
 - {created: ! '2022-01-04 11:33:05.251713', doi: 10.5281/zenodo.5817053, name: Mitochondria

--- a/scripts/block_pending_resources.py
+++ b/scripts/block_pending_resources.py
@@ -23,15 +23,6 @@ def main(
                 v["status"] = "blocked"
                 made_changes = True
 
-        if any(v["status"] == "accepted" for v in resource["versions"]):
-            resource_status = "accepted"
-        else:
-            resource_status = "blocked"
-
-        if resource["status"] != resource_status:
-            resource["status"] = resource_status
-            made_changes = True
-
         if made_changes:
             yaml.dump(resource, resource_path)
 


### PR DESCRIPTION
The script block_pending_resources.py will try to block the entire resource automatically if there is no available version available, and this course problem when we submitted an item and we want to block the first version and but not the version comes later.

This is a quick fix to not block the entire resource automatically.