### PR TITLE
Save owners to the generated rdf field

### DIFF
--- a/collection/10.5281/zenodo.5764892/resource.yaml
+++ b/collection/10.5281/zenodo.5764892/resource.yaml
@@ -1,5 +1,6 @@
 doi: 10.5281/zenodo.5764892
 id: 10.5281/zenodo.5764892
+owners: [77626]
 status: accepted
 type: model
 versions:

--- a/collection/10.5281/zenodo.5817052/resource.yaml
+++ b/collection/10.5281/zenodo.5817052/resource.yaml
@@ -1,5 +1,6 @@
 doi: 10.5281/zenodo.5817052
 id: 10.5281/zenodo.5817052
+owners: [271523]
 status: accepted
 type: model
 versions:

--- a/collection/10.5281/zenodo.5847355/resource.yaml
+++ b/collection/10.5281/zenodo.5847355/resource.yaml
@@ -1,5 +1,6 @@
 doi: 10.5281/zenodo.5847355
 id: 10.5281/zenodo.5847355
+owners: [77626]
 status: accepted
 type: model
 versions:

--- a/scripts/generate_collection_rdf.py
+++ b/scripts/generate_collection_rdf.py
@@ -94,6 +94,9 @@ def main(
 
             this_version["validation_summaries"] = val_summaries
 
+            if "owners" in r:
+                this_version["owners"] = r["owners"]
+
             if latest_version is None:
                 latest_version = this_version
                 latest_version["id"] = r["id"]

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -79,6 +79,10 @@ def write_resource(
             "type": resource_type,
         }
 
+    if "owners" in new_version:
+        resource["owners"] = new_version["owners"]
+        del new_version["owners"]
+
     if "doi" in resource and not resource["doi"]:
         del resource["doi"]
 
@@ -150,6 +154,7 @@ def update_from_zenodo(
             new_version = {
                 "version_id": doi,
                 "doi": doi,
+                "owners": hit["owners"],
                 "created": created,
                 "status": "accepted",  # default to accepted
                 "source": source,


### PR DESCRIPTION
The website requires the `owners` field to determine who owns the model.