### PR TITLE
Generate summary

### DIFF
--- a/collection/10.5281/zenodo.5744489/resource.yaml
+++ b/collection/10.5281/zenodo.5744489/resource.yaml
@@ -3,6 +3,6 @@ id: 10.5281/zenodo.5744489
 status: blocked
 type: model
 versions:
-- {created: ! '2021-12-25 18:54:04.735769', doi: 10.5281/zenodo.5744490, name: UNet
+- {created: '2021-12-25 18:54:04.735769', doi: 10.5281/zenodo.5744490, name: UNet
     2D Nuclei Broad, source: 'https://zenodo.org/api/files/3f422e1b-a64e-40d3-89d1-29038d2f405d/rdf.yaml',
   status: blocked, version_id: 10.5281/zenodo.5744490, version_name: revision 1}

--- a/collection/10.5281/zenodo.5764892/resource.yaml
+++ b/collection/10.5281/zenodo.5764892/resource.yaml
@@ -4,6 +4,6 @@ owners: [77626]
 status: accepted
 type: model
 versions:
-- {created: ! '2021-12-07 18:02:09.736653+00:00', doi: 10.5281/zenodo.5764893, name: NucleiSegmentationBoundaryModel,
+- {created: '2021-12-07 18:02:09.736653+00:00', doi: 10.5281/zenodo.5764893, name: NucleiSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/8137780b-871f-4d7e-b130-a63847ece4d8/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5764893, version_name: revision 1}

--- a/collection/10.5281/zenodo.5817052/resource.yaml
+++ b/collection/10.5281/zenodo.5817052/resource.yaml
@@ -4,9 +4,9 @@ owners: [271523]
 status: accepted
 type: model
 versions:
-- {created: ! '2022-01-14 15:26:42.112259', doi: 10.5281/zenodo.5850574, name: Mitochondria
+- {created: '2022-01-14 15:26:42.112259', doi: 10.5281/zenodo.5850574, name: Mitochondria
     segmentation - TEM - 2D U-Net - ZeroCostDL4Mic, source: 'https://zenodo.org/api/files/5ff5e52c-a708-4c93-98c2-160c29204800/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5850574, version_name: revision 1}
-- {created: ! '2022-01-04 11:33:05.251713', doi: 10.5281/zenodo.5817053, name: Mitochondria
+- {created: '2022-01-04 11:33:05.251713', doi: 10.5281/zenodo.5817053, name: Mitochondria
     segmentation - TEM - 2D U-Net - ZeroCostDL4Mic, source: 'https://zenodo.org/api/files/e14f65fa-f480-4503-944a-209e3119b38b/rdf.yaml',
   status: blocked, version_id: 10.5281/zenodo.5817053, version_name: revision 1}

--- a/collection/10.5281/zenodo.5847355/resource.yaml
+++ b/collection/10.5281/zenodo.5847355/resource.yaml
@@ -4,9 +4,9 @@ owners: [77626]
 status: accepted
 type: model
 versions:
-- {created: ! '2022-01-18 21:31:33.668428', doi: 10.5281/zenodo.5874728, name: CovidIFCellSegmentationBoundaryModel,
+- {created: '2022-01-18 21:31:33.668428', doi: 10.5281/zenodo.5874728, name: CovidIFCellSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/612ad5b1-5978-4481-9c8c-e28b97d6b927/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5874728, version_name: revision 1}
-- {created: ! '2022-01-13 21:13:49.264581', doi: 10.5281/zenodo.5847356, name: CovidIFCellSegmentationBoundaryModel,
+- {created: '2022-01-13 21:13:49.264581', doi: 10.5281/zenodo.5847356, name: CovidIFCellSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/5b0d4c67-6d0a-462c-914c-07bebe594bd8/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5847356, version_name: revision 1}

--- a/collection/10.5281/zenodo.5869899/resource.yaml
+++ b/collection/10.5281/zenodo.5869899/resource.yaml
@@ -4,6 +4,6 @@ owners: [77626]
 status: accepted
 type: model
 versions:
-- {created: ! '2022-01-18 10:03:26.939252', doi: 10.5281/zenodo.5869900, name: LiveCellSegmentationBoundaryModel,
+- {created: '2022-01-18 10:03:26.939252', doi: 10.5281/zenodo.5869900, name: LiveCellSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/a6d477fe-9412-4064-b7e6-67f057fec920/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5869900, version_name: revision 1}

--- a/collection/10.5281/zenodo.5874741/resource.yaml
+++ b/collection/10.5281/zenodo.5874741/resource.yaml
@@ -4,6 +4,6 @@ owners: [77626]
 status: accepted
 type: model
 versions:
-- {created: ! '2022-01-18 22:01:09.315638', doi: 10.5281/zenodo.5874742, name: NeuronEMSegmentationBoundaryModel,
+- {created: '2022-01-18 22:01:09.315638', doi: 10.5281/zenodo.5874742, name: NeuronEMSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/a6d65a8b-4fed-453f-89f6-515a2a73a99e/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5874742, version_name: revision 1}

--- a/collection/10.5281/zenodo.5874841/resource.yaml
+++ b/collection/10.5281/zenodo.5874841/resource.yaml
@@ -4,6 +4,6 @@ owners: [77626]
 status: accepted
 type: model
 versions:
-- {created: ! '2022-01-18 23:04:49.485980', doi: 10.5281/zenodo.5874842, name: MitochondriaEMSegmentationBoundaryModel,
+- {created: '2022-01-18 23:04:49.485980', doi: 10.5281/zenodo.5874842, name: MitochondriaEMSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/2d9489cd-a4dd-4730-8a71-577d0fcd0f5c/rdf.yaml',
   status: accepted, version_id: 10.5281/zenodo.5874842, version_name: revision 1}

--- a/scripts/imjoy_plugin_parser.py
+++ b/scripts/imjoy_plugin_parser.py
@@ -147,8 +147,10 @@ def convert_config_to_rdf(plugin_config, plugin_id, source_url=None):
     rdf["tags"] = tags
 
     docs = plugin_config.get("docs")
-    if docs:
+    if isinstance(docs, dict):
         rdf["documentation"] = docs.get("content")
+    elif isinstance(docs, str):
+        rdf["documentation"] = docs
     rdf["covers"] = plugin_config.get("cover")
     # make sure we have a list
     if not rdf["covers"]:

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -155,7 +155,7 @@ def update_from_zenodo(
                 "version_id": doi,
                 "doi": doi,
                 "owners": hit["owners"],
-                "created": created,
+                "created": str(created),
                 "status": "accepted",  # default to accepted
                 "source": source,
                 "name": name,


### PR DESCRIPTION
Currently the rdf.yaml used by the website contains all the fields which is unnecessary for generating an overview of the items. This Pr simplifies it by generating a summary for each item.

We also move some non-standard fields under config so we can make sure the cached rdf is also valid, e.g. for models.