### PR TITLE
Add additional link to ilastik/live-cell-boundary-model

### DIFF
--- a/collection/10.5281/zenodo.5869899/resource.yaml
+++ b/collection/10.5281/zenodo.5869899/resource.yaml
@@ -6,4 +6,5 @@ type: model
 versions:
 - {created: '2022-01-18 10:03:26.939252', doi: 10.5281/zenodo.5869900, name: LiveCellSegmentationBoundaryModel,
   source: 'https://zenodo.org/api/files/a6d477fe-9412-4064-b7e6-67f057fec920/rdf.yaml',
+  links: [ilastik/live-cell-boundary-model, ilastik/livecell_dataset, ilastik/ilastik, deepimagej/deepimagej, imjoy/BioImageIO-Packager],
   status: accepted, version_id: 10.5281/zenodo.5869900, version_name: revision 1}


### PR DESCRIPTION
@constantinpape I will try to use the override feature to see if we get the additional bioengine app icon on the live cell boundary model.