### PR TITLE
[WIP] Fix PR validation

### DIFF
--- a/.github/workflows/collection_main.yaml
+++ b/.github/workflows/collection_main.yaml
@@ -1,0 +1,170 @@
+name: build collection and generate auto-update PRs
+concurrency: main  # do not run this workflow in parallel
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron:  '0 1,13 * * *'
+  workflow_dispatch: # triggered by http endpoints
+  workflow_call:  # triggered by other workflow
+
+jobs:
+  update-known-resources:
+    runs-on: ubuntu-latest
+    outputs:
+      updated_resources_matrix: ${{ steps.update_known.outputs.updated_resources_matrix }}
+      found_new_resources: ${{ steps.update_known.outputs.found_new_resources }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # get all branches to check for pending resources by checking if auto-update-... branch exists
+    - name: install script deps
+      run: pip install bioimageio.spec
+    - name: update known resources
+      id: update_known
+      run: python scripts/update_known_resources.py --collection-dir collection --max-resource-count 15 --dist dist
+    - name: "Upload updated collection"
+      uses: actions/upload-artifact@v2
+      with:
+        name: updated-collection
+        path: collection
+        retention-days: 1
+
+  build-collection:  # deploy collection rdf to gh-pages
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: install script deps
+      run: pip install typer ruamel.yaml bioimageio.spec boltons lxml requests
+    - name: generate collection rdf
+      run: python scripts/generate_collection_rdf.py
+    - name: Deploy collection rdf to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        clean: false
+        branch: gh-pages
+        folder: dist
+
+  get-pending-validation:
+    needs: build-collection
+    runs-on: ubuntu-latest
+    outputs:
+      pending_matrix: ${{ steps.get_pending.outputs.pending_matrix }}
+      has_pending_matrix: ${{ steps.get_pending.outputs.has_pending_matrix }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: install script deps
+      run: pip install typer ruamel.yaml bioimageio.spec
+    - name: get pending validations
+      id: get_pending
+      run: python scripts/get_pending_validations.py
+    - name: debug found pending ${{ steps.get_pending.outputs.has_pending_matrix }}
+      run: echo ${{ steps.get_pending.outputs.pending_matrix }}
+
+  validate:
+    needs: get-pending-validation
+    if: needs.get-pending-validation.outputs.has_pending_matrix == 'yes'
+    uses: bioimage-io/collection-bioimage-io/.github/workflows/validate_resources.yaml@main
+    with:
+      pending_matrix: ${{ needs.get-pending-validation.outputs.pending_matrix }}
+      has_pending_matrix: ${{ needs.get-pending-validation.outputs.has_pending_matrix }}
+      deploy: 'yes'
+
+  build-collection-again:
+    needs: [collect-new-resources, get-pending-validation, validate]
+    if: always() && needs.get-pending-validation.outputs.has_pending_matrix == 'yes'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: install script deps
+      run: pip install typer ruamel.yaml bioimageio.spec boltons lxml requests
+    - name: generate collection rdf
+      run: python scripts/generate_collection_rdf.py
+    - name: Deploy collection rdf to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        clean: false
+        branch: gh-pages
+        folder: dist
+
+  open-pr:
+    needs: [collect-new-resources]
+    if: needs.collect-new-resources.outputs.found_new_resources == 'yes'
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1  # to limit content creation (PRs) on github to avoid getting temporary blocked
+      fail-fast: false
+      # matrix: update: [{resource_id:..., resource_name:..., new_version_ids:..., new_version_sources:..., maintainers: ...}, ...]
+      matrix: ${{ fromJson(needs.collect-new-resources.outputs.updated_resources_matrix) }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: download new collection
+      uses: actions/download-artifact@v2
+      with:
+        name: updated-collection
+        path: updated-collection
+    - name: replace resource item folder
+      run: |
+        mkdir -p "collection/${{ matrix.update.resource_id }}"
+        cp -r "updated-collection/${{ matrix.update.resource_id }}"/* "collection/${{ matrix.update.resource_id }}"
+        rm -rf updated-collection
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.PAT }}  # using a PAT will make sure we can trigger the CI in PR
+        commit-message: 'Update ${{ matrix.update.resource_id }}'
+        committer: GitHub <noreply@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        signoff: false
+        branch: auto-update-${{ matrix.update.resource_id }}
+        delete-branch: false  # true does not seem to actually delete the PR branch...? we delete the branch in block_pending.yaml
+        title: 'Update ${{ matrix.update.resource_name }}'
+        body: |
+          This is an automatic PR created by the @bioimageiobot regarding changes to the resource item ${{ matrix.update.resource_id }}.
+          The following version(s) will be added:
+          ${{ matrix.update.new_version_ids_md }}
+
+          You can find their corresponding RDF files here:
+          ${{ matrix.update.new_version_sources_md }}
+
+          The corresponding deployment preview (will be) available at: [gh-pages](/bioimage-io/collection-bioimage-io/tree/gh-pages/resources/${{ matrix.update.resource_id }})
+          
+          Please review the changes and make sure the new item or version(s) pass the following check list:
+          - [ ] Passed the BioImage.IO Spec validator (static validation);
+          - [ ] Passed the BioImage.IO CI tests (dynamic validations);
+          - [ ] The meta information for the RDF item is complete;
+            - [ ] The tags is complete and describes the model;
+            - [ ] Naming is intuitive and descriptive, example:  Multi-Organ Nucleus Segmentation (StarDist 2D);
+            - [ ] Authors are provided;
+            - [ ] Documentation is complete;
+              * For models, include an overview, describe how the model is trained, what is the training data, how to use the model, how to validate the results and list the references. TODO: Model documentation template.
+          - [ ] Approved by at least one of the BioImage.IO admin team member.
+
+          Maintainers: ${{ matrix.update.maintainers }}
+          
+          Note: If you updated or re-uploaded another version for the current item on Zenodo, this PR won't be changed automatically. To proceed, you can do the following:
+           1. Edit the current resource.yaml and mark the top-level `status` field as `accepted`, but change the `status` under the current version to `blocked`.
+           2. Merge this PR for now, wait until the CI on the main branch to complete. It should detect the new versions and create another PR for the new version. You can take it from there instead.
+
+        labels: |
+          auto-update
+        draft: false

--- a/scripts/generate_collection_rdf.py
+++ b/scripts/generate_collection_rdf.py
@@ -61,9 +61,6 @@ def main(
         resource_id = r["id"]
         latest_version = None
         for version_info in r["versions"]:
-            if version_info["status"] == "blocked":
-                continue
-
             # Ignore the name in the version info
             del version_info["name"]
 

--- a/scripts/update_known_resources.py
+++ b/scripts/update_known_resources.py
@@ -1,18 +1,24 @@
 import json
 import subprocess
+import warnings
 from collections import defaultdict
 from datetime import datetime
+from distutils.version import StrictVersion
 from pathlib import Path
 from pprint import pprint
 from typing import DefaultDict, Dict, List, Literal, Optional, Tuple, Union
 
 import requests
 import typer
+from marshmallow import missing
 from ruamel.yaml import YAML
 
-from utils import set_gh_actions_outputs
+from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
+from imjoy_plugin_parser import get_plugin_as_rdf
+from utils import resolve_partners, set_gh_actions_outputs
 
 yaml = YAML(typ="safe")
+
 
 
 def get_rdf_source(*, rdf_urls: List[str], doi, concept_doi) -> dict:
@@ -176,7 +182,14 @@ def update_from_zenodo(
                 update_with_new_version(new_version, resource_doi, rdf, updated_resources)
 
 
-def main(collection_dir: Path = Path(__file__).parent / "../collection", max_resource_count: int = 3):
+
+
+
+def main(
+    collection_dir: Path = Path(__file__).parent / "../collection",
+    max_resource_count: int = 3,
+    dist: Path = Path(__file__).parent / "../dist",
+):
     updated_resources: DefaultDict[str, List[Dict[str, Union[str, datetime]]]] = defaultdict(list)
 
     update_from_zenodo(collection_dir, updated_resources)

--- a/scripts/update_partner_resources.py
+++ b/scripts/update_partner_resources.py
@@ -1,0 +1,46 @@
+import warnings
+from distutils.version import StrictVersion
+from pathlib import Path
+
+import typer
+from ruamel.yaml import YAML
+
+from utils import resolve_partners, update_resource_rdfs
+
+yaml = YAML(typ="safe")
+
+
+def main(
+    dist: Path = Path(__file__).parent / "../dist",
+    gh_pages: Path = Path(__file__).parent / "../gh-pages",
+    rdf_template_path: Path = Path(__file__).parent / "../collection_rdf_template.yaml",
+    current_collection_format: str = "0.2.2",
+):
+    partner_versions_path = gh_pages / "partner_versions.yaml"
+    if partner_versions_path.exists():
+        partner_versions = {k: StrictVersion(v) for k, v in yaml.load(partner_versions_path).items()}
+    else:
+        partner_versions = {}
+
+    rdf = yaml.load(rdf_template_path)
+
+    partners, updated_partner_resources, updated_partner_versions, ignored_partners = resolve_partners(
+        rdf, current_format=current_collection_format, partner_versions=partner_versions
+    )
+    if "partners" in rdf["config"]:
+        rdf["config"]["partners"] = partners
+        print(f"{len(updated_partner_versions)}/{len(partners)} partners updated")
+
+    if ignored_partners:
+        warnings.warn(f"ignored invalid partners: {ignored_partners}")  # todo: raise instead of warning?
+
+    for r in updated_partner_resources:
+        yaml.dump(r, dist / "partner_collection" / r["id"] / "resource.yaml")
+        update_resource_rdfs(dist, r)
+
+    yaml.dump({k: str(v) for k, v in updated_partner_versions.items()}, partner_versions_path)
+    yaml.dump(partners, dist / "partner_details.yaml")
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
after a lot of back and forth, I think I have a good plan to solve the issues with overriding RDFs and treating partner and zenodo resources as equal as reasonable.


```
                   partners                                                     zenodo


gh-pages:     partner_collection/                 rdfs/                      orig_rdfs/
gh-pages:                          ->  (bioimageio collection) rdf.yaml
                         |                         ^^                           |
                         |_________________________||___________________________|
main:                                                     + update from collection/
                                                
                                                                
```


 - partner_collection/ gets updates when the partner collection version is bumped. This directly updates the respective rdfs in rdfs/ as well (push to gh-pages from main ci)
 - for rdfs from zenodo we keep orig_rdfs/ to check every time if the resource in collection/ has changed (i.e. if the updated rdf in rdf/ has changed or is new). updates are being pushed to gh-pages from a main ci
 - in a PR the orig rdf from orig_rdf/ is updated in the PR CI before being validated, nothing needs to be pushed to gh-pages then
 - the final collection rdf is generated from the collection/ and partner_collection/ folder while all known rdfs are present in rdf/ we don't have to iterate and resolve all partners again/check zenodo.

note: I basically renamed the gh-pages folder `resources/` to `rdfs/` as they are by now valid rdfs. In the collection folders the files are still called `resource.yaml` as they are not valid rdf and just keeping resource id linked to the version ids..
