### PR TITLE
Use pip for tensorflow 1.15

### DIFF
--- a/scripts/static_validation.py
+++ b/scripts/static_validation.py
@@ -82,11 +82,13 @@ def get_default_env(
         conda_env["dependencies"].append("cpuonly")
 
     if tensorflow_version is not None:
-        tf_major, tf_minor, *_ = v.version
+        tf_major, tf_minor, tf_patch = tensorflow_version.version
+
         # tensorflow 1.15 is not available on conda, so we need to inject this as a pip dependency
-        if int(tf_major) == 1 and int(tf_minor) == 15:
-            conda_env["dependencies"].append(f"-pip: -tensorflow {get_version_range(tensorflow_version)}")
-        else:
+        if (tf_major, tf_minor) == (1, 15):
+            conda_env["dependencies"].append("pip")
+            conda_env["dependencies"].append({"pip": [f"tensorflow {get_version_range(tensorflow_version)}"]})
+        else:  # use conda otherwise
             conda_env["dependencies"].append(f"tensorflow {get_version_range(tensorflow_version)}")
 
     return conda_env

--- a/scripts/static_validation.py
+++ b/scripts/static_validation.py
@@ -60,7 +60,7 @@ def get_env_from_deps(deps: Dependencies):
 
 
 def get_version_range(v: StrictVersion) -> str:
-    v_major, v_minor, v_path = v.version
+    v_major, v_minor, v_patch = v.version
     return f">={v_major}.{v_minor},<{v_major}.{v_minor + 1}"
 
 
@@ -82,7 +82,12 @@ def get_default_env(
         conda_env["dependencies"].append("cpuonly")
 
     if tensorflow_version is not None:
-        conda_env["dependencies"].append(f"tensorflow {get_version_range(tensorflow_version)}")
+        tf_major, tf_minor, *_ = v.version
+        # tensorflow 1.15 is not available on conda, so we need to inject this as a pip dependency
+        if int(tf_major) == 1 and int(tf_minor) == 15:
+            conda_env["dependencies"].append(f"-pip: -tensorflow {get_version_range(tensorflow_version)}")
+        else:
+            conda_env["dependencies"].append(f"tensorflow {get_version_range(tensorflow_version)}")
 
     return conda_env
 


### PR DESCRIPTION
We need to use pip to resolve tensorflow 1.15 dependencies. This will fix the issues in #270. 
(Tensorflow 1.15 is not available via conda, and I am a bit confused that this gets resolved at all.)

I am however not sure how to inject pip dependencies in the current design; this is just showing the intention of what needs to be done ;).