### PR TITLE
pin numpy for tf 1.15

### DIFF
--- a/scripts/static_validation.py
+++ b/scripts/static_validation.py
@@ -88,7 +88,10 @@ def get_default_env(
         if (tf_major, tf_minor) == (1, 15):
             conda_env["dependencies"].append("pip")
             conda_env["dependencies"].append("python >=3.7,<3.8")  # tf 1.15 not available for py>=3.8
-            conda_env["dependencies"].append({"pip": [f"tensorflow {get_version_range(tensorflow_version)}"]})
+            conda_env["dependencies"].append(
+                {"pip": [f"tensorflow {get_version_range(tensorflow_version)}", "numpy >=1.20"]}
+                # numpy dep to avoid "No module named 'numpy.typing'" as pip otherwise downgrades numpy!?
+            )
         else:  # use conda otherwise
             conda_env["dependencies"].append(f"tensorflow {get_version_range(tensorflow_version)}")
 


### PR DESCRIPTION
locally I could not reprodue the behavior in https://github.com/bioimage-io/collection-bioimage-io/runs/5359798987?check_suite_focus=true

conda installed  numpy 1.21, which is then downgraded by pip to numpy 1.18, which is not compatible with imageio 2.16.1 installed by conda (which does not get downgraded by pip)

I hope pinning numpy >=1.20 will avoid this issue. Either way the mixed conda/pip setup for tf 1.15 should be avoided... Which makes me think of only installing python 3.7 with conda and everything else (bioimageio.core) with pip... I'll make a separate PR for this.. 