### PR TITLE
resolve file paths relative to remote resource location after updating rdf

### DIFF
--- a/.github/workflows/validate_resources.yaml
+++ b/.github/workflows/validate_resources.yaml
@@ -139,11 +139,6 @@ jobs:
         name: preview
         path: dist/gh_pages_update
         retention-days: 90
-    - name: debug
-      run: |
-        ls -d dist/gh_pages_update/*
-        ls -d dist/gh_pages_update/*/*
-        ls -d dist/gh_pages_update/*/*/*
     - name: Deploy to gh-pages 🚀
       if: contains(inputs.deploy_to, 'gh-pages')
       uses: JamesIves/github-pages-deploy-action@v4.2.3

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -226,7 +226,7 @@ def write_rdfs_for_resource(resource: dict, dist: Path, only_for_version_id: Opt
                 rdf, rdf_name, rdf_root = resolve_rdf_source(version_info["rdf_source"])
                 if not isinstance(rdf, dict):
                     raise TypeError(type(rdf))
-                rdf["rdf_root"] = rdf_root  # we use this after updating the rdf to resolve remote sources
+                rdf["root_path"] = rdf_root  # we use this after updating the rdf to resolve remote sources
             except Exception as e:
                 warnings.warn(f"Failed to load {version_info['rdf_source']}: {e}")
                 rdf = {


### PR DESCRIPTION
This PR solves the bug that file paths were not converted to urls, if the unupdated rdf fails static validation, see https://github.com/bioimage-io/collection-bioimage-io/pull/371 as an example