### PR TITLE
Better netlify preview

### DIFF
--- a/.github/workflows/comment_preview.yaml
+++ b/.github/workflows/comment_preview.yaml
@@ -11,10 +11,6 @@ jobs:
     name: comment links to previews in pull request
     runs-on: windows-2019
     steps:
-    - name: debug pr number
-      run: echo ${{ github.event.number }}
-    - name: debug original ref
-      run: echo ${{ github.event.workflow_run.head_branch }}
 #    - uses: izhangzhihao/delete-comment@master
 #      with:
 #        github_token: ${{ secrets.PAT }}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
   <!-- Redirect in JavaScript with meta refresh fallback above in noscript -->
   <script>
-  window.location.href = window.location.href.split("?")[0].replace('index.html', '') + 'collection.json';
+  window.location.href = 'https://bioimage.io/#/?repo=' + window.location.href.split("?")[0].replace('index.html', '') + 'collection.json';
   </script>
   </body>
 </html>


### PR DESCRIPTION
While netlify build works now, the preview still links to the collection.json file and not how bioimage.io would look with that collection loaded...
e.g. https://github.com/bioimage-io/collection-bioimage-io/pull/440

This PR adds bioimage.io/#/?repo= to the redirect... (e.g. current preview redirects to https://bioimage.io/#/?repo=https%3A%2F%2Fdeploy-preview-444--collection-bioimage-io.netlify.app%2Fcollection.json)
