### PR TITLE
pip for all tf1 versions

### DIFF
--- a/scripts/static_validation.py
+++ b/scripts/static_validation.py
@@ -81,8 +81,8 @@ def get_default_env(
         conda_env["dependencies"].append("cpuonly")
 
     if tensorflow_version is not None:
-        # tensorflow 1.15 is not available on conda, so we need to inject this as a pip dependency
-        if (tensorflow_version.major, tensorflow_version.minor) == (1, 15):
+        # tensorflow 1 is not available on conda, so we need to inject this as a pip dependency
+        if tensorflow_version.major == 1:
             assert opset_version is None
             assert pytorch_version is None
             conda_env["dependencies"] = ["pip", "python >=3.7,<3.8"]  # tf 1.15 not available for py>=3.8


### PR DESCRIPTION
This PR changes the default environment if only the tensorflow version is given for a model.

Before this PR we used pip only for tensorflow 1.15. This PR changes this to use pip for all TF 1 versions. 

Should help fixing tests for https://github.com/bioimage-io/collection-bioimage-io/pull/441