### PR TITLE
Change BiaPy repo to BiaPyX

### DIFF
--- a/collection_rdf_template.yaml
+++ b/collection_rdf_template.yaml
@@ -83,7 +83,7 @@ config:
       branch: main
       collection_file_name: collection.yaml
     - id: biapy
-      repository: danifranco/BiaPy-bioimage-io
+      repository: BiaPyX/BiaPy-bioimage-io
       branch: main
       collection_file_name: collection.yaml
 collection: []


### PR DESCRIPTION
Hi,

We have moved [BiaPy](https://github.com/BiaPyX/BiaPy) repository to a new organization so it's just a minor update to change it here too. 

Thanks!

Dani